### PR TITLE
Allow CPU and CUDA kernels to wait on each other

### DIFF
--- a/src/backends/cuda.jl
+++ b/src/backends/cuda.jl
@@ -72,8 +72,14 @@ function (obj::Kernel{CUDA})(args...; ndrange=nothing, dependencies=nothing, wor
     stream = next_stream()
     if dependencies !== nothing
         for event in dependencies
-            @assert event isa CudaEvent
-            CUDAdrv.wait(event.event, stream)
+            if event isa CudaEvent
+                CUDAdrv.wait(event.event, stream)
+            end
+        end
+        for event in dependencies
+            if !(event isa CudaEvent)
+                wait(event, ()->yield())
+            end
         end
     end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -161,3 +161,26 @@ if has_cuda_gpu()
     wait(kernel_val!(CUDA())(A,Val(3), ndrange=size(A)))
     @test all((a)->a==3, A)
 end
+
+@kernel function kernel_empty()
+    return
+end
+if has_cuda_gpu()
+    @testset "CPU--CUDA dependencies" begin
+        event1 = kernel_empty(CPU(), 1)(ndrange=1)
+        event2 = kernel_empty(CUDA(), 1)(ndrange=1)
+        event3 = kernel_empty(CPU(), 1)(ndrange=1)
+        event4 = kernel_empty(CUDA(), 1)(ndrange=1)
+        event5 = kernel_empty(CUDA(), 1)(ndrange=1, dependencies=(event1, event2, event3, event4))
+        wait(event5)
+        @test event5 isa KernelAbstractions.Event
+
+        event1 = kernel_empty(CPU(), 1)(ndrange=1)
+        event2 = kernel_empty(CUDA(), 1)(ndrange=1)
+        event3 = kernel_empty(CPU(), 1)(ndrange=1)
+        event4 = kernel_empty(CUDA(), 1)(ndrange=1)
+        event5 = kernel_empty(CPU(), 1)(ndrange=1, dependencies=(event1, event2, event3, event4))
+        wait(event5)
+        @test event5 isa KernelAbstractions.Event
+    end
+end


### PR DESCRIPTION
This allows the event system to be used to coordinate work done on the
host with work done on the device.