### PR TITLE
Allow CPU kernels to depend on default events

### DIFF
--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -50,7 +50,7 @@ function __run(obj, ndrange, iterspace, args, dependencies)
         if dependencies !== nothing
             cpu_tasks = Core.Task[]
             for event in dependencies
-                if event isa CPUEvent
+                if event isa CPUEvent && event.task isa Core.Task
                     push!(cpu_tasks, event.task)
                 end
             end

--- a/test/test.jl
+++ b/test/test.jl
@@ -184,3 +184,9 @@ if has_cuda_gpu()
         @test event5 isa KernelAbstractions.Event
     end
 end
+
+@testset "CPU dependencies" begin
+    event = Event(CPU())
+    event = kernel_empty(CPU(), 1)(ndrange=1, dependencies=(event))
+    wait(event)
+end


### PR DESCRIPTION
With the addition of the default event (used to synchronize the CUDA
kernels with the default stream), `CPUEvent`s come in two flavors.  This
change allows CPU kernels to depend on the flavor that comes from
`event = Event(CPU())` where `event.task === nothing`.