### PR TITLE
Allow MultiEvent to be created from an Event

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -2,7 +2,7 @@ module KernelAbstractions
 
 export @kernel
 export @Const, @localmem, @private, @uniform, @synchronize, @index, groupsize, @print
-export Device, GPU, CPU, CUDA, Event, MultiEvent
+export Device, GPU, CPU, CUDA, Event, MultiEvent, NoneEvent
 export async_copy!
 
 
@@ -72,6 +72,9 @@ struct MultiEvent{T} <: Event
     function MultiEvent(events::Tuple{Vararg{<:Event}})
         evs = tuplejoin(map(flatten, events)...)
         new{typeof(evs)}(evs)
+    end
+    function MultiEvent(event::E) where {E<:Event}
+        new{Tuple{E}}((event,))
     end
 end
 MultiEvent(::Nothing) = MultiEvent()

--- a/test/test.jl
+++ b/test/test.jl
@@ -195,3 +195,24 @@ end
     event = kernel_empty(CPU(), 1)(ndrange=1, dependencies=(event))
     wait(event)
 end
+
+@testset "MultiEvent" begin
+  event1 = kernel_empty(CPU(), 1)(ndrange=1)
+  event2 = kernel_empty(CPU(), 1)(ndrange=1)
+  event3 = kernel_empty(CPU(), 1)(ndrange=1)
+
+  @test MultiEvent(nothing) isa Event
+  @test MultiEvent(event1) isa Event
+  @test MultiEvent((event1, event2, event3)) isa Event
+end
+
+if has_cuda_gpu()
+  @testset "MultiEvent CUDA" begin
+    event1 = kernel_empty(CUDA(), 1)(ndrange=1)
+    event2 = kernel_empty(CPU(), 1)(ndrange=1)
+    event3 = kernel_empty(CUDA(), 1)(ndrange=1)
+
+    @test MultiEvent(event1) isa Event
+    @test MultiEvent((event1, event2, event3)) isa Event
+  end
+end


### PR DESCRIPTION
When building a `MultiEvent` from a `dependencies` argument, it can be
useful to have a `MultiEvent` be created from a single `Event`.