### PR TITLE
implement NVTXT

### DIFF
--- a/src/extras/extras.jl
+++ b/src/extras/extras.jl
@@ -4,4 +4,7 @@ include("loopinfo.jl")
 using .LoopInfo
 export @unroll
 
+include("timeline.jl")
+using .Timeline
+
 end # module

--- a/src/extras/timeline.jl
+++ b/src/extras/timeline.jl
@@ -1,0 +1,97 @@
+module Timeline
+
+module NVTXT
+    const LOG_FILE=Ref{IOStream}()
+    const SHOULD_LOG=Ref{Bool}(false)
+
+    function __init__()
+        if haskey(ENV, "KERNELABSTRACTIONS_TIMELINE")
+            SHOULD_LOG[] = true
+        else
+            SHOULD_LOG[] = false
+            return
+        end
+        pid = Libc.getpid()
+        LOG_FILE[] = open("ka-$pid.nvtxt", "w")
+        initialize()
+        atexit() do
+            close(LOG_FILE[])
+        end
+    end
+
+    function initialize()
+        SHOULD_LOG[] || return
+        io = LOG_FILE[]
+        pid = Libc.getpid()
+        print(io, """
+        SetFileDisplayName, KernelAbstractions
+        @RangeStartEnd, Start, End, ThreadId, Message
+        ProcessId = $pid
+        CategoryId = 1
+        Color = Blue
+        TimeBase = ClockMonotonicRaw
+        @RangePush, Time, ThreadId, Message
+        ProcessId = $pid
+        CategoryId = 1
+        Color = Blue
+        TimeBase = ClockMonotonicRaw
+        @RangePop, Time, ThreadId
+        ProcessId = $pid
+        TimeBase = ClockMonotonicRaw
+        @Marker, Time, ThreadId, Message
+        ProcessId = $pid
+        CategoryId = 1
+        Color = Blue
+        TimeBase = ClockMonotonicRaw
+        """)
+    end
+
+    function push_range(msg)
+        SHOULD_LOG[] || return
+        time = time_ns()
+        io = LOG_FILE[]
+        print(io, "RangePush, ")
+        print(io, time)
+        println(io, ", ", Base.Threads.threadid(), ", \"", msg, "\"")
+    end
+
+    function pop_range()
+        SHOULD_LOG[] || return
+        time = time_ns()
+        io = LOG_FILE[]
+        print(io, "RangePop, ")
+        print(io, time)
+        println(io, ", ", Base.Threads.threadid())
+    end
+
+    struct Range
+        start::UInt64
+        msg::String
+    end
+
+    start_range(msg::String) = Range(time_ns(), msg)
+    function end_range(r::Range)
+        SHOULD_LOG[] || return
+        time = time_ns()
+        io = LOG_FILE[]
+        print(io, "RangeStartEnd, ")
+        show(io, r.start)
+        print(io, ", ")
+        show(io, time)
+        println(io, ", ", Base.Threads.threadid(), ", \"", r.msg, "\"")
+    end
+
+    function mark(msg::String)
+        SHOULD_LOG[] || return
+        time = time_ns()
+        io = LOG_FILE[]
+        print(io, "Marker, ")
+        show(io, time)
+        println(io, ", ", Base.Threads.threadid(), ", \"", msg, "\"")
+    end
+end # NVTXT
+
+function range_push end
+function mark end
+
+end


### PR DESCRIPTION
So the idea is that we have a common output format for the CPU backend as well as the GPU backend.
This implements NVTXT so that you can load these annotations with nsys

```
export KERNELABSTRACTIONS_TIMELINE=true

julia> import KernelAbstractions.Extras.Timeline.NVTXT
julia> NVTXT.push_range("Costly computation")
julia> NVTXT.pop_range()
```

These leaves a file in the cwd:

```
cat ka-31089.nvtxt
SetFileDisplayName, KernelAbstractions
@RangeStartEnd, Start, End, ThreadId, Message
ProcessId = 31089
CategoryId = 1
Color = Blue
TimeBase = Manual
@RangePush, Time, ThreadId, Message
ProcessId = 31089
CategoryId = 1
Color = Blue
TimeBase = Manual
@RangePop, Time, ThreadId
ProcessId = 31089
TimeBase = Manual
@Marker, Time, ThreadId, Message
ProcessId = 31089
CategoryId = 1
Color = Blue
TimeBase = Manual
RangePush, 515251367655304, 1, "Costly computation"
RangePop, 515256007484357, 1
```

Convert to qdrep 
```
LD_LIBRARY_PATH=/opt/nsight-systems-2020.1.1/host-linux-x64/ /opt/nsight-systems-2020.1.1/host-linux-x64/ImportNvtxt --cmd create --nvtxt ka-31089.nvtxt -o report.qdrep

LD_LIBRARY_PATH=/opt/nsight-systems-2020.1.1/host-linux-x64/ /opt/nsight-systems-2020.1.1/host-linux-x64/ImportNvtxt --cmd info -i report.qdrep 
Analysis start (ns)     515251367000000
Analysis end (ns)       515256008000000
```