### PR TITLE
async_copy! fixes

### DIFF
--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -20,8 +20,6 @@ function wait(cpu::CPU, ev::MultiEvent, progress=nothing)
 end
 
 function wait(::CPU, ev::CPUEvent, progress=nothing)
-    ev.task === nothing && return
-    
     if progress === nothing
         wait(ev.task)
     else

--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -32,7 +32,7 @@ end
 function async_copy!(::CPU, A, B; dependencies=nothing)
     wait(CPU(), MultiEvent(dependencies), yield)
     copyto!(A, B)
-    return CPUEvent(nothing)
+    return NoneEvent()
 end
 
 function (obj::Kernel{CPU})(args...; ndrange=nothing, workgroupsize=nothing, dependencies=nothing)

--- a/test/async_copy.jl
+++ b/test/async_copy.jl
@@ -22,4 +22,4 @@ M = 1024
 if has_cuda_gpu()
     copy_test(CUDA(), CuArray, M)
 end
-copy_test(CPU(), CuArray, M)
+copy_test(CPU(), Array, M)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,10 @@ end
     include("nditeration.jl")
 end
 
+@testset "async_copy!" begin
+    include("async_copy.jl")
+end
+
 include("print_test.jl")
 
 include("examples.jl")


### PR DESCRIPTION
This adds the `async_copy!` tests to `runtests.jl` and cleans up some minor issues related to `NoneEvent`.