### PR TITLE
Forbid waiting in CUDA on a CPUEvents

### DIFF
--- a/src/backends/cuda.jl
+++ b/src/backends/cuda.jl
@@ -90,6 +90,8 @@ include("cusynchronization.jl")
 import .CuSynchronization: unsafe_volatile_load, unsafe_volatile_store!
 import CUDAdrv: Mem
 
+wait(::CUDA, ev::CPUEvent, progress=nothing, stream=nothing) = error("Not currently implemented.")
+
 # This implements waiting for a CPUEvent on the GPU.
 # Most importantly this implementation needs to be asynchronous w.r.t to the host,
 # otherwise one could introduce deadlocks with outside event systems.
@@ -99,7 +101,7 @@ import CUDAdrv: Mem
 # to set trhe flag 1->2 so that we can deallocate the memory.
 # TODO:
 # - In case of an error we should probably also kill the waiting GPU code.
-function wait(::CUDA, ev::CPUEvent, progress=nothing, stream=CuDefaultStream())
+function unsafe_wait(::CUDA, ev::CPUEvent, progress=nothing, stream=CuDefaultStream())
     buf = Mem.alloc(Mem.HostBuffer, sizeof(UInt32), Mem.HOSTREGISTER_DEVICEMAP)
     unsafe_store!(convert(Ptr{UInt32}, buf), UInt32(0))
     # TODO: Switch to `@spawn` when CUDAnative.jl is thread-safe

--- a/test/events.jl
+++ b/test/events.jl
@@ -28,7 +28,7 @@ if has_cuda_gpu()
     barrier = Base.Threads.Event()
     cpu_event = Event(wait, barrier)
 
-    wait(CUDA(), cpu_event) # Event edge on CuDefaultStream
+    KernelAbstractions.unsafe_wait(CUDA(), cpu_event) # Event edge on CuDefaultStream
     gpu_event = Event(CUDA()) # Event on CuDefaultStream
 
     notify(barrier)

--- a/test/test.jl
+++ b/test/test.jl
@@ -171,9 +171,9 @@ if has_cuda_gpu()
         event2 = kernel_empty(CUDA(), 1)(ndrange=1)
         event3 = kernel_empty(CPU(), 1)(ndrange=1)
         event4 = kernel_empty(CUDA(), 1)(ndrange=1)
-        event5 = kernel_empty(CUDA(), 1)(ndrange=1, dependencies=(event1, event2, event3, event4))
-        wait(event5)
-        @test event5 isa KernelAbstractions.Event
+        @test_throws ErrorException event5 = kernel_empty(CUDA(), 1)(ndrange=1, dependencies=(event1, event2, event3, event4))
+        # wait(event5)
+        # @test event5 isa KernelAbstractions.Event
 
         event1 = kernel_empty(CPU(), 1)(ndrange=1)
         event2 = kernel_empty(CUDA(), 1)(ndrange=1)


### PR DESCRIPTION
The current implementation can lead to deadlocks without careful
considerations.  Until this CPU->CUDA synchronization can be done more
robustly, we disable this type of waiting by default.