### PR TITLE
Improve launch performance of kernels some more

### DIFF
--- a/src/backends/cuda.jl
+++ b/src/backends/cuda.jl
@@ -209,7 +209,7 @@ end
 Cassette.@context CUDACtx
 
 function mkcontext(kernel::Kernel{CUDA}, _ndrange, iterspace)
-    metadata = CompilerMetadata{ndrange(kernel), true}(_ndrange, iterspace)
+    metadata = CompilerMetadata{ndrange(kernel), DynamicCheck()}(_ndrange, iterspace)
     Cassette.disablehooks(CUDACtx(pass = CompilerPass, metadata=metadata))
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -23,7 +23,7 @@ end
 @inline __iterspace(cm::CompilerMetadata)  = cm.iterspace
 @inline __groupindex(cm::CompilerMetadata) = cm.groupindex
 @inline __groupsize(cm::CompilerMetadata) = size(workitems(__iterspace(cm)))
-@inline __dynamic_checkbounds(::CompilerMetadata{NDRange, CB}) where {NDRange, CB} = CB
+@inline __dynamic_checkbounds(::CompilerMetadata{NDRange, CB}) where {NDRange, CB} = CB isa DynamicCheck
 @inline __ndrange(cm::CompilerMetadata{NDRange}) where {NDRange<:StaticSize}  = CartesianIndices(get(NDRange))
 @inline __ndrange(cm::CompilerMetadata{NDRange}) where {NDRange<:DynamicSize} = cm.ndrange
 

--- a/src/nditeration.jl
+++ b/src/nditeration.jl
@@ -2,8 +2,12 @@ module NDIteration
 
 export _Size, StaticSize, DynamicSize, get
 export NDRange, blocks, workitems, expand
+export DynamicCheck, NoDynamicCheck
 
 import Base.@pure
+
+struct DynamicCheck end
+struct NoDynamicCheck end
 
 abstract type _Size end
 struct DynamicSize <: _Size end
@@ -118,7 +122,7 @@ needs to perform dynamic bounds-checking.
             return fld1(ndrange[I], workgroupsize[I])
         end
 
-        return blocks, workgroupsize, dynamic[]
+        return blocks, workgroupsize, dynamic[] ? DynamicCheck() : NoDynamicCheck()
     end
 end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -13,26 +13,26 @@ identity(x)=x
     let kernel = KernelAbstractions.Kernel{CPU, StaticSize{(64,)}, DynamicSize, typeof(identity)}(identity)
         iterspace, dynamic = KernelAbstractions.partition(kernel, (128,), nothing)
         @test length(blocks(iterspace)) == 2
-        @test !dynamic
+        @test dynamic isa NoDynamicCheck
 
         iterspace, dynamic = KernelAbstractions.partition(kernel, (129,), nothing)
         @test length(blocks(iterspace)) == 3
-        @test dynamic
+        @test dynamic isa DynamicCheck
 
         iterspace, dynamic = KernelAbstractions.partition(kernel, (129,), (64,))
         @test length(blocks(iterspace)) == 3
-        @test dynamic
+        @test dynamic isa DynamicCheck
 
         @test_throws ErrorException KernelAbstractions.partition(kernel, (129,), (65,))
     end
     let kernel = KernelAbstractions.Kernel{CPU, StaticSize{(64,)}, StaticSize{(128,)}, typeof(identity)}(identity)
         iterspace, dynamic = KernelAbstractions.partition(kernel, (128,), nothing)
         @test length(blocks(iterspace)) == 2
-        @test !dynamic
+        @test dynamic isa NoDynamicCheck
 
         iterspace, dynamic = KernelAbstractions.partition(kernel, nothing, nothing)
         @test length(blocks(iterspace)) == 2
-        @test !dynamic
+        @test dynamic isa NoDynamicCheck
 
         @test_throws ErrorException KernelAbstractions.partition(kernel, (129,), nothing)
     end
@@ -121,7 +121,7 @@ end
     let kernel = constarg(CPU(), 8, (1024,))
         # this is poking at internals
         iterspace = NDRange{1, StaticSize{(128,)}, StaticSize{(8,)}}();
-        ctx = KernelAbstractions.mkcontext(kernel, 1, nothing, iterspace, Val(false))
+        ctx = KernelAbstractions.mkcontext(kernel, 1, nothing, iterspace, Val(NoDynamicCheck()))
         AT = Array{Float32, 2}
         IR = sprint() do io
             code_llvm(io, KernelAbstractions.Cassette.overdub, 


### PR DESCRIPTION
Using this script https://github.com/JuliaGPU/KernelAbstractions.jl/pull/80#issuecomment-605210053

Before:
```
[ Info: Ka Launch
BenchmarkTools.Trial:
  memory estimate:  816 bytes
  allocs estimate:  9
  --------------
  minimum time:     4.301 μs (0.00% GC)
  median time:      4.585 μs (0.00% GC)
  mean time:        4.617 μs (0.46% GC)
  maximum time:     220.415 μs (97.08% GC)
  --------------
  samples:          10000
  evals/sample:     7
```

After:

```[ Info: Ka Launch
BenchmarkTools.Trial:
  memory estimate:  816 bytes
  allocs estimate:  9
  --------------
  minimum time:     98.354 ns (0.00% GC)
  median time:      121.497 ns (0.00% GC)
  mean time:        148.127 ns (17.31% GC)
  maximum time:     1.882 μs (87.36% GC)
  --------------
  samples:          9587
  evals/sample:     951
```
