### PR TITLE
Make CPU kernels synchronous if `dependencies=nothing`

### DIFF
--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -95,8 +95,16 @@ function (obj::Kernel{CPU})(args...; ndrange=nothing, workgroupsize=nothing, dep
         ndrange = nothing
     end
 
-    Event(__run, obj, ndrange, iterspace, args, Val(dynamic),
-          dependencies=dependencies, progress=progress)
+    if dependencies === nothing
+        # we can execute this kernel directly, removing the overhead of spawning a task
+        # if you need the the kernel to be executed asynchronously, pass a `NoneEvent` as
+        # a dependency.
+        __run(obj, ndrange, iterspace, args, Val(dynamic))
+        return NoneEvent()
+    else
+        return Event(__run, obj, ndrange, iterspace, args, Val(dynamic),
+              dependencies=dependencies, progress=progress)
+    end
 end
 
 # Inference barriers

--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -99,16 +99,16 @@ function (obj::Kernel{CPU})(args...; ndrange=nothing, workgroupsize=nothing, dep
         # we can execute this kernel directly, removing the overhead of spawning a task
         # if you need the the kernel to be executed asynchronously, pass a `NoneEvent` as
         # a dependency.
-        __run(obj, ndrange, iterspace, args, Val(dynamic))
+        __run(obj, ndrange, iterspace, args, dynamic)
         return NoneEvent()
     else
-        return Event(__run, obj, ndrange, iterspace, args, Val(dynamic),
+        return Event(__run, obj, ndrange, iterspace, args, dynamic,
               dependencies=dependencies, progress=progress)
     end
 end
 
 # Inference barriers
-function __run(obj, ndrange, iterspace, args, ::Val{dynamic}) where dynamic
+function __run(obj, ndrange, iterspace, args, dynamic)
     N = length(iterspace)
     Nthreads = Threads.nthreads()
     if Nthreads == 1
@@ -122,16 +122,16 @@ function __run(obj, ndrange, iterspace, args, ::Val{dynamic}) where dynamic
         len, rem = 1, 0
     end
     if Nthreads == 1
-        __thread_run(1, len, rem, obj, ndrange, iterspace, args, Val(dynamic))
+        __thread_run(1, len, rem, obj, ndrange, iterspace, args, dynamic)
     else
         @sync for tid in 1:Nthreads
-            Threads.@spawn __thread_run(tid, len, rem, obj, ndrange, iterspace, args, Val(dynamic))
+            Threads.@spawn __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
         end
     end
     return nothing
 end
 
-function __thread_run(tid, len, rem, obj, ndrange, iterspace, args, ::Val{dynamic}) where dynamic
+function __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
     # compute this thread's iterations
     f = 1 + ((tid-1) * len)
     l = f + len - 1
@@ -148,7 +148,7 @@ function __thread_run(tid, len, rem, obj, ndrange, iterspace, args, ::Val{dynami
     # run this thread's iterations
     for i = f:l
         block = @inbounds blocks(iterspace)[i]
-        ctx = mkcontext(obj, block, ndrange, iterspace, Val(dynamic))
+        ctx = mkcontext(obj, block, ndrange, iterspace, dynamic)
         Cassette.overdub(ctx, obj.f, args...)
     end
     return nothing
@@ -156,8 +156,8 @@ end
 
 Cassette.@context CPUCtx
 
-function mkcontext(kernel::Kernel{CPU}, I, _ndrange, iterspace, ::Val{dynamic}) where dynamic
-    metadata = CompilerMetadata{ndrange(kernel), dynamic}(I, _ndrange, iterspace)
+function mkcontext(kernel::Kernel{CPU}, I, _ndrange, iterspace, ::Dynamic) where Dynamic
+    metadata = CompilerMetadata{ndrange(kernel), Dynamic}(I, _ndrange, iterspace)
     Cassette.disablehooks(CPUCtx(pass = CompilerPass, metadata=metadata))
 end
 

--- a/src/backends/cuda.jl
+++ b/src/backends/cuda.jl
@@ -219,7 +219,7 @@ end
 Cassette.@context CUDACtx
 
 function mkcontext(kernel::Kernel{CUDA}, _ndrange, iterspace)
-    metadata = CompilerMetadata{ndrange(kernel), DynamicCheck()}(_ndrange, iterspace)
+    metadata = CompilerMetadata{ndrange(kernel), DynamicCheck}(_ndrange, iterspace)
     Cassette.disablehooks(CUDACtx(pass = CompilerPass, metadata=metadata))
 end
 

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -23,7 +23,7 @@ end
 @inline __iterspace(cm::CompilerMetadata)  = cm.iterspace
 @inline __groupindex(cm::CompilerMetadata) = cm.groupindex
 @inline __groupsize(cm::CompilerMetadata) = size(workitems(__iterspace(cm)))
-@inline __dynamic_checkbounds(::CompilerMetadata{NDRange, CB}) where {NDRange, CB} = CB isa DynamicCheck
+@inline __dynamic_checkbounds(::CompilerMetadata{NDRange, CB}) where {NDRange, CB} = CB <: DynamicCheck
 @inline __ndrange(cm::CompilerMetadata{NDRange}) where {NDRange<:StaticSize}  = CartesianIndices(get(NDRange))
 @inline __ndrange(cm::CompilerMetadata{NDRange}) where {NDRange<:DynamicSize} = cm.ndrange
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -169,7 +169,7 @@ if has_cuda_gpu()
     @testset "CPU--CUDA dependencies" begin
         event1 = kernel_empty(CPU(), 1)(ndrange=1)
         event2 = kernel_empty(CUDA(), 1)(ndrange=1)
-        event3 = kernel_empty(CPU(), 1)(ndrange=1)
+        event3 = kernel_empty(CPU(), 1, dependencies=event1)(ndrange=1)
         event4 = kernel_empty(CUDA(), 1)(ndrange=1)
         @test_throws ErrorException event5 = kernel_empty(CUDA(), 1)(ndrange=1, dependencies=(event1, event2, event3, event4))
         # wait(event5)


### PR DESCRIPTION
In order to have them be asynchronous the user can pass in a
`NoneEvent()`. This makes small kernels faster. 

```
~/builds/julia-1.3.1/bin/julia --color=yes --project=. -L ~/perfka.jl
[ Info: Ka + Wait Static
BenchmarkTools.Trial: 
  memory estimate:  80 bytes
  allocs estimate:  3
  --------------
  minimum time:     195.714 ns (0.00% GC)
  median time:      213.559 ns (0.00% GC)
  mean time:        239.629 ns (1.00% GC)
  maximum time:     3.369 μs (86.47% GC)
  --------------
  samples:          10000
  evals/sample:     555

[ Info: Ka Launch
BenchmarkTools.Trial: 
  memory estimate:  816 bytes
  allocs estimate:  9
  --------------
  minimum time:     132.569 ns (0.00% GC)
  median time:      158.833 ns (0.00% GC)
  mean time:        226.427 ns (16.90% GC)
  maximum time:     8.768 μs (96.22% GC)
  --------------
  s amples:          6944
  evals/sample:     893
```

`KA Launch` was measured with `dependencies=NoneEvent()`, script from #80