### PR TITLE
Use hostcall for wait and stream GC

### DIFF
--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -75,14 +75,16 @@ import Base: wait
 
 wait(ev::CudaEvent, progress=yield) = wait(CPU(), ev, progress)
 
-function wait(::CPU, ev::CudaEvent, progress=yield)
-    if progress === nothing
-        CUDA.synchronize(ev.event)
-    else
-        while !isdone(ev)
-            progress()
-        end
+function wait(::CPU, ev::CudaEvent, progress=nothing)
+    isdone(ev) && return nothing
+
+    event = Base.Threads.Event()
+    stream = next_stream()
+    wait(CUDADevice(), ev, nothing, stream)
+    CUDA.launch(stream) do
+        notify(event)
     end
+    wait(event)
 end
 
 # Use this to synchronize between computation using the CuDefaultStream

--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -81,7 +81,7 @@ function wait(::CPU, ev::CudaEvent, progress=nothing)
     event = Base.Threads.Event()
     stream = next_stream()
     wait(CUDADevice(), ev, nothing, stream)
-    CUDA.launch(stream) do
+    CUDA.launch(;stream) do
         notify(event)
     end
     wait(event)


### PR DESCRIPTION
While looking at a profile from @lcw I noticed that
we spend a lot of CPU cycles on `cuEventQuery`. 

The second change is more questionable since it might 
make GPU launches slower (have yet to measure costs).