### PR TITLE
Allow ndrange to be zero

### DIFF
--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -95,6 +95,10 @@ function (obj::Kernel{CPU})(args...; ndrange=nothing, workgroupsize=nothing, dep
         ndrange = nothing
     end
 
+    if length(blocks(iterspace)) == 0
+        return MultiEvent(dependencies)
+    end
+
     Event(__run, obj, ndrange, iterspace, args, dynamic,
           dependencies=dependencies, progress=progress)
 end

--- a/test/test.jl
+++ b/test/test.jl
@@ -218,6 +218,25 @@ if has_cuda_gpu()
   end
 end
 
+@testset "Zero iteration space" begin
+    event1 = kernel_empty(CPU(), 1)(ndrange=1)
+    event2 = kernel_empty(CPU(), 1)(ndrange=0; dependencies=event1)
+    @test event2 == MultiEvent(event1)
+    event = kernel_empty(CPU(), 1)(ndrange=0)
+    @test event == MultiEvent(nothing)
+end
+
+
+if has_cuda_gpu()
+    @testset "Zero iteration space CUDA" begin
+        event1 = kernel_empty(CUDA(), 1)(ndrange=1)
+        event2 = kernel_empty(CUDA(), 1)(ndrange=0; dependencies=event1)
+        @test event2 == MultiEvent(event1)
+        event = kernel_empty(CUDA(), 1)(ndrange=0)
+        @test event == MultiEvent(nothing)
+    end
+end
+
 @testset "return statement" begin
     try
         @eval @kernel function kernel_return()


### PR DESCRIPTION
This provides a shortcut for kernels with a zero ndrange.  It also
prevents trying to launch a CUDA kernel with zero blocks (which is an
error).