### PR TITLE
Rework private memory on the CPU

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -134,7 +134,7 @@ end
 """
     @private T dims
 """
-macro private(T, dims)
+macro private(T, dims = ())
     quote
         $Scratchpad($(esc(T)), Val($(esc(dims))))
     end

--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -245,3 +245,9 @@ end
 Base.@propagate_inbounds function Base.getindex(A::ScratchArray{N}, I...) where {N}
     return view(A.data, ntuple(_ -> Colon(), Val(N))..., I...)
 end
+Base.@propagate_inbounds function Base.getindex(A::ScratchArray{0}, I...)
+    return A.data[I...]
+end
+Base.@propagate_inbounds function Base.setindex!(A::ScratchArray{0}, val, I...)
+    A.data[I...] = val
+end

--- a/src/backends/cpu.jl
+++ b/src/backends/cpu.jl
@@ -242,10 +242,6 @@ Base.eltype(a::ScratchArray) = eltype(a.data)
     return ScratchArray{length(Dims)}(MArray{__size((Dims..., __groupsize(ctx.metadata)...)), T}(undef))
 end
 
-Base.@propagate_inbounds function Base.getindex(A::ScratchArray, I...)
-    return A.data[I...]
-end
-
-Base.@propagate_inbounds function Base.setindex!(A::ScratchArray, val, I...)
-    A.data[I...] = val
+Base.@propagate_inbounds function Base.getindex(A::ScratchArray{N}, I...) where {N}
+    return view(A.data, ntuple(_ -> Colon(), Val(N))..., I...)
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -216,10 +216,8 @@ function emit(loop)
     if !(isempty(loop.stmts) || all(s->s isa LineNumberNode, loop.stmts))
         body = Expr(:block, loop.stmts...)
         body = postwalk(body) do expr
-            if @capture(expr, A_[i__])
-                if A in loop.private
-                    return :($A[$(i...), $(idx).I...])
-                end
+            if expr in loop.private
+                return :($expr[$(idx).I...])
             end
             return expr
         end

--- a/test/private.jl
+++ b/test/private.jl
@@ -43,6 +43,12 @@ end
     end
 end
 
+@kernel function lengthtest(A)
+    priv = @private eltype(A) (2, 3)
+    I = @index(Global, Linear)
+    @inbounds A[I] = length(priv)
+end
+
 function harness(backend, ArrayT)
     A = ArrayT{Int}(undef, 64)
     wait(private(backend, 16)(A, ndrange=size(A)))
@@ -60,6 +66,10 @@ function harness(backend, ArrayT)
     B = ArrayT{Bool}(undef, size(A)...)
     wait(typetest(backend, 16)(A, B, ndrange=size(A)))
     @test all(B)
+
+    A .= 0
+    wait(lengthtest(backend, 16)(A, ndrange=size(A)))
+    @test all(A .== 6)
 end
 
 @testset "kernels" begin


### PR DESCRIPTION
This PR changes `@private` memory on the CPU to return views to the underlying array with additional dimensions. The main rationale is that it makes passing private arrays to functions more straightforward. For example, currently `@private` vectors in our kernels are passed
as `@views f!(v[:], ...)` which is a bit confusing to the uninitiated. Moreover, this change made is easy to enable scalar `@private` variables.

CC: @jkozdon 