### PR TITLE
Remove the Buildkite "soft fail" on Julia nightly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -19,8 +19,6 @@ steps:
     agents:
       queue: "juliagpu"
       cuda: "*"
-    soft_fail:
-      - exit_status: 1
     timeout_in_minutes: 60
 
 env:


### PR DESCRIPTION
This setting is very dangerous. It makes it seem like Buildkite was passing on Julia nightly, when in fact Buildkite was failing on Julia nightly.