### PR TITLE
Use the registered version of CUDA.jl for Buildkite on Julia 1.6-nightly and Julia nightly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,15 +15,9 @@ steps:
     plugins:
       - JuliaCI/julia#v0.6:
           version: "1.6-nightly"
-      # - JuliaCI/julia-test#v0.3:
-      # - JuliaCI/julia-coverage#v0.3:
-      #     codecov: true
-    command: |
-      julia --project -e '
-        using Pkg
-        Pkg.pkg"add CUDA#master"
-        Pkg.build()
-        Pkg.test()'
+      - JuliaCI/julia-test#v0.3:
+      - JuliaCI/julia-coverage#v0.3:
+          codecov: true
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -33,15 +27,9 @@ steps:
     plugins:
       - JuliaCI/julia#v0.6:
           version: "nightly"
-      # - JuliaCI/julia-test#v0.3:
-      # - JuliaCI/julia-coverage#v0.3:
-      #     codecov: true
-    command: |
-      julia --project -e '
-        using Pkg
-        Pkg.pkg"add CUDA#master"
-        Pkg.build()
-        Pkg.test()'
+      - JuliaCI/julia-test#v0.3:
+      - JuliaCI/julia-coverage#v0.3:
+          codecov: true
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Adapt = "0.4, 1.0, 2.0, 3.0"
-CUDA = "~1.0, ~1.1, ~1.2, 1.3, 2"
+CUDA = "2.4"
 Cassette = "0.3.3"
 MacroTools = "0.5"
 SpecialFunctions = "0.10, 1.0"


### PR DESCRIPTION
Fixes #196 