### PR TITLE
More robust test/examples.jl

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -23,7 +23,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,9 +8,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia -e 'using Pkg; Pkg.add(name="Run", version="0.1")'
-      - julia -e 'using Run; Run.prepare_test()'
-      - julia -e 'using Run; Run.test()'
+      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -25,9 +23,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia -e 'using Pkg; Pkg.add(name="Run", version="0.1")'
-      - julia -e 'using Run; Run.prepare_test()'
-      - julia -e 'using Run; Run.test()'
+      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -42,9 +38,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia -e 'using Pkg; Pkg.add(name="Run", version="0.1")'
-      - julia -e 'using Run; Run.prepare_test()'
-      - julia -e 'using Run; Run.test()'
+      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,7 +8,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -23,7 +23,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -38,7 +38,7 @@ steps:
     commands:
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -6,6 +6,9 @@ on:
       - staging
       - trying
     tags: '*'
+defaults:
+  run:
+    shell: bash
 jobs:
   CI-julia-1-6-nightly:
     name: CI-julia-1-6-nightly

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test test/runtests.jl
+      - run: julia --project=test --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - run: julia -e 'using Pkg; pkg"add Run@0.1"'
       - run: julia -e 'using Run; Run.prepare_test()'
       - run: julia -e 'using Run; Run.test()'

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -42,10 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
-      - run: julia -e 'using Pkg; pkg"add Run@0.1"'
-      - run: julia -e 'using Run; Run.prepare_test()'
-      - run: julia -e 'using Run; Run.test()'
+      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -42,6 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
+      - run: julia --project=test test/runtests.jl
       - run: julia -e 'using Pkg; pkg"add Run@0.1"'
       - run: julia -e 'using Run; Run.prepare_test()'
       - run: julia -e 'using Run; Run.test()'

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -42,7 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -42,9 +42,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia -e 'using Pkg; pkg"add Run@0.1"'
-      - run: julia -e 'using Run; Run.prepare_test()'
-      - run: julia -e 'using Run; Run.test()'
+      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -6,6 +6,9 @@ on:
       - staging
       - trying
     tags: '*'
+defaults:
+  run:
+    shell: bash
 jobs:
   CI-julia-nightly:
     name: CI-julia-nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,7 @@ jobs:
             ${{ runner.os }}-
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
       - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia -e 'using Pkg; pkg"add Run@0.1"'
-      - run: julia -e 'using Run; Run.prepare_test()'
-      - run: julia -e 'using Run; Run.test()'
+      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - staging
       - trying
     tags: '*'
+defaults:
+  run:
+    shell: bash
 jobs:
   CI:
     name: CI
@@ -58,7 +61,6 @@ jobs:
         with:
           version: '1'
       - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
-        shell: bash
         env:
           JULIA_PKG_SERVER: ""
       - run: |
@@ -80,7 +82,6 @@ jobs:
         with:
           version: 'nightly'
       - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
-        shell: bash
         env:
           JULIA_PKG_SERVER: ""
       - run: |

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,18 @@
+@info(
+    "Start testing with:",
+    pwd(),
+    Base.current_project(),
+    Base.load_path(),
+    Text(Base.load_path_setup_code()),
+)
+let Pkg = Base.require(Base.PkgId(
+        Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"),
+        "Pkg",
+    ))
+    Pkg.status(mode = Pkg.PKGMODE_MANIFEST)
+end
+@info "Trying to `using KernelAbstractions` etc..."
+
 using KernelAbstractions
 using CUDAKernels
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,18 +1,3 @@
-@info(
-    "Start testing with:",
-    pwd(),
-    Base.current_project(),
-    Base.load_path(),
-    Text(Base.load_path_setup_code()),
-)
-let Pkg = Base.require(Base.PkgId(
-        Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"),
-        "Pkg",
-    ))
-    Pkg.status(mode = Pkg.PKGMODE_MANIFEST)
-end
-@info "Trying to `using KernelAbstractions` etc..."
-
 using KernelAbstractions
 using CUDAKernels
 using Test


### PR DESCRIPTION
This is a PR onto #200.

I think the test is failing because `Base.current_project()` doesn't work nicely with `--project`:

```
arakaki@amdci2 ~/.j/d/KernelAbstractions (vc/split)> pwd
/home/arakaki/.julia/dev/KernelAbstractions
arakaki@amdci2 ~/.j/d/KernelAbstractions (vc/split)> julia --startup-file=no --project=test -e 'display(Base.current_project())'
"/home/arakaki/.julia/dev/KernelAbstractions/Project.toml"⏎
arakaki@amdci2 ~/.j/d/KernelAbstractions (vc/split)> julia --startup-file=no --project=test -e 'display(Base.load_path())'
3-element Array{String,1}:
 "/home/arakaki/.julia/dev/KernelAbstractions/test/Project.toml"
 "/home/arakaki/.julia/environments/v1.5/Project.toml"
 "/home/arakaki/opt/julia/julia-1.5.2/share/julia/stdlib/v1.5"⏎
```

A quick workaround may be to use `Base.load_path_setup_code()` to propagate load path etc to the child processes.
