### PR TITLE
Simplify some of the testing commands

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,9 +6,8 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     commands:
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - julia .ci/develop.jl
+      - julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -21,9 +20,8 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     commands:
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - julia .ci/develop.jl
+      - julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
     agents:
       queue: "juliagpu"
       cuda: "*"
@@ -36,9 +34,8 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     commands:
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - julia .ci/develop.jl
+      - julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
     agents:
       queue: "juliagpu"
       cuda: "*"

--- a/.ci/bin/get-github-status-list.jl
+++ b/.ci/bin/get-github-status-list.jl
@@ -1,0 +1,209 @@
+import GitHub
+
+const BRANCH_OR_COMMIT = Union{GitHub.Branch, GitHub.Commit}
+
+struct AlwaysAssertionError
+    msg::String
+end
+
+function always_assert(condition::Bool, msg::String)
+    if !condition
+        throw(AlwaysAssertionError(msg))
+    end
+    return nothing
+end
+
+function _get_branch(repo;
+                     api::GitHub.GitHubAPI,
+                     auth::GitHub.Authorization,
+                     branch)
+    return GitHub.branch(api, repo, branch; auth = auth)
+end
+
+function _get_commit(repo;
+                     api::GitHub.GitHubAPI,
+                     auth::GitHub.Authorization,
+                     commit)
+    return GitHub.commit(api, repo, commit; auth = auth)
+end
+
+function _get_commit_or_branch(repo;
+                               api::GitHub.GitHubAPI,
+                               auth::GitHub.Authorization,
+                               branch = nothing,
+                               commit = nothing)
+    if (branch isa Nothing) && (commit isa Nothing)
+        msg = string(
+            "You must provide either ",
+            "the branch or the commit",
+        )
+        throw(ArgumentError(msg))
+    elseif (!(branch isa Nothing)) && (!(commit isa Nothing))
+        msg = string(
+            "You cannot provide both ",
+            "a branch and a commit. ",
+            "You must provide exactly one.",
+        )
+        throw(ArgumentError(msg))
+    elseif (!(branch isa Nothing))
+        return _get_branch(repo; api=api, auth=auth, branch=branch)
+    else
+        always_assert(!(commit isa Nothing), "!(commit isa Nothing)")
+        return _get_commit(repo; api = api, auth = auth, commit = commit)
+    end
+end
+
+function get_statuses(repo;
+                      api::GitHub.GitHubAPI,
+                      auth::GitHub.Authorization,
+                      branch,
+                      commit)
+    branch_or_commit = _get_commit_or_branch(
+        repo;
+        api = api,
+        auth = auth,
+        branch = branch,
+        commit = commit,
+    )
+    return get_statuses(repo, branch_or_commit; api, auth)
+end
+
+function get_statuses(repo,
+                      branch_or_commit::BRANCH_OR_COMMIT;
+                      api::GitHub.GitHubAPI,
+                      auth::GitHub.Authorization)
+    combined_status = GitHub.status(
+        api,
+        repo,
+        branch_or_commit;
+        auth = auth,
+    )
+    combined_status_statuses = combined_status.statuses
+    statuses, _ = GitHub.statuses(
+        api,
+        repo,
+        branch_or_commit;
+        auth = auth,
+    )
+    status_contexts = vcat(
+        [x.context for x in combined_status_statuses],
+        [x.context for x in statuses],
+    )
+    unique!(status_contexts)
+    sort!(status_contexts)
+    return status_contexts
+end
+
+function _convert_to_commit(repo,
+                            branch::GitHub.Branch;
+                            api::GitHub.GitHubAPI,
+                            auth::GitHub.Authorization)
+    commit = GitHub.commit(api, repo, branch; auth = auth)
+    return commit
+end
+
+function _convert_to_commit(repo,
+                            commit::GitHub.Commit;
+                            api::GitHub.GitHubAPI,
+                            auth::GitHub.Authorization)
+    return commit
+end
+
+function _get_commit_sha_from_commit(commit::GitHub.Commit)
+    return commit.sha
+end
+
+function get_check_runs(repo;
+                        api::GitHub.GitHubAPI,
+                        auth::GitHub.Authorization,
+                        branch,
+                        commit)
+    return nothing
+end
+
+function get_check_runs(repo,
+                        branch_or_commit::BRANCH_OR_COMMIT;
+                        api::GitHub.GitHubAPI,
+                        auth::GitHub.Authorization)
+    commit = _convert_to_commit(
+        repo,
+        branch_or_commit;
+        api = api,
+        auth = auth,
+    )
+    commit_sha = _get_commit_sha_from_commit(commit)
+    endpoint = "/repos/$(repo.full_name)/commits/$(commit_sha)/check-runs"
+    check_runs = GitHub.gh_get_json(
+        api,
+        endpoint;
+        auth = auth,
+    )
+    check_run_names = [x["name"] for x in check_runs["check_runs"]]
+    unique!(check_run_names)
+    sort!(check_run_names)
+    return check_run_names
+end
+
+function get_statuses_and_check_runs(repo;
+                                     api::GitHub.GitHubAPI,
+                                     auth::GitHub.Authorization,
+                                     branch,
+                                     commit)
+    status_contexts_and_check_run_names = get_statuses_and_check_runs(
+        repo,
+        branch_or_commit;
+        api = api,
+        auth = auth)
+    unique!(status_contexts_and_check_run_names)
+    sort!(status_contexts_and_check_run_names)
+    return status_contexts_and_check_run_names
+end
+
+function get_statuses_and_check_runs(repo,
+                                     branch_or_commit::BRANCH_OR_COMMIT;
+                                     api::GitHub.GitHubAPI,
+                                     auth::GitHub.Authorization)
+
+    status_contexts = get_statuses(
+        repo,
+        branch_or_commit;
+        api = api,
+        auth = auth,
+    )
+    check_run_names = get_check_runs(
+        repo,
+        branch_or_commit;
+        api = api,
+        auth = auth,
+    )
+    status_contexts_and_check_run_names = vcat(
+        status_contexts,
+        check_run_names,
+    )
+    unique!(status_contexts_and_check_run_names)
+    sort!(status_contexts_and_check_run_names)
+    return status_contexts_and_check_run_names
+end
+
+function _show(v::AbstractVector)
+    for (i, x) ∈ enumerate(v)
+        println(stdout, "$(i). $(x)")
+    end
+end
+
+function main()
+    api = GitHub.DEFAULT_API
+    auth = GitHub.AnonymousAuth()
+    repo = GitHub.repo(api, "JuliaGPU/KernelAbstractions.jl"; auth = auth);
+    # branch_name = "master"
+    # branch_name = "staging"
+    branch_name = "trying"
+    branch = _get_commit_or_branch(repo; api = api, auth = auth, branch = branch_name);
+    result = get_statuses_and_check_runs(repo, branch; api = api, auth = auth)
+    @info "" branch_name
+    show(result)
+    _show(result)
+    return result
+end
+
+main()

--- a/.ci/develop.jl
+++ b/.ci/develop.jl
@@ -1,0 +1,11 @@
+import Pkg
+
+root_directory = dirname(@__DIR__)
+
+kernelabstractions = Pkg.PackageSpec(path = root_directory)
+cudakernels = Pkg.PackageSpec(path = joinpath(root_directory, "lib", "CUDAKernels"))
+
+Pkg.develop(kernelabstractions)
+Pkg.develop(cudakernels)
+
+Pkg.precompile()

--- a/.github/workflows/ci-julia-1.6-nightly.yml
+++ b/.github/workflows/ci-julia-1.6-nightly.yml
@@ -40,9 +40,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: julia .ci/develop.jl
+      - run: julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -40,9 +40,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: julia .ci/develop.jl
+      - run: julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,8 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd()))'
-      - run: julia --project=test -e 'using Pkg; Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))'
-      - run: JULIA_LOAD_PATH=@ julia --project=test --color=yes --check-bounds=yes --code-coverage=user --depwarn=yes test/runtests.jl
+      - run: julia .ci/develop.jl
+      - run: julia -e 'import Pkg; Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage = true)'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:
@@ -61,12 +60,7 @@ jobs:
       - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))
-            Pkg.instantiate()'
+      - run: julia --project=docs .ci/develop.jl
       - run: julia --project=docs docs/make.jl
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -82,14 +76,11 @@ jobs:
       - run: julia --color=yes -e 'using Pkg; VERSION >= v"1.5-" && !isdir(joinpath(DEPOT_PATH[1], "registries", "General")) && Pkg.Registry.add("General")'
         env:
           JULIA_PKG_SERVER: ""
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.develop(PackageSpec(path=joinpath(pwd(),"lib","CUDAKernels")))
-            Pkg.instantiate()'
+      - run: julia --project=docs .ci/develop.jl
       - run: |
           julia --project=docs -e '
             using Documenter: doctest
             using KernelAbstractions
-            doctest(KernelAbstractions)'
+            using CUDAKernels
+            doctest(KernelAbstractions; manual = true)
+            doctest(CUDAKernels; manual = false)'

--- a/lib/CUDAKernels/Project.toml
+++ b/lib/CUDAKernels/Project.toml
@@ -18,3 +18,9 @@ Cassette = "0.3.3"
 KernelAbstractions = "0.6"
 SpecialFunctions = "0.10, 1.0"
 StaticArrays = "0.12, 1.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/lib/CUDAKernels/test/runtests.jl
+++ b/lib/CUDAKernels/test/runtests.jl
@@ -1,0 +1,2 @@
+using CUDAKernels
+using Test

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDAKernels = "72cfdca4-0801-4ab0-bf6a-d52aa10adc57"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 KernelAbstractions = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"


### PR DESCRIPTION
This pull request simplifies some of the CI testing commands. In particular, in this PR, we use the following command to test the packages in this repo:
- `Pkg.test(["KernelAbstractions", "CUDAKernels"]; coverage=true)`