### PR TITLE
Test suite: add a newline at the end of a print statement

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -29,4 +29,4 @@ status = [
   "Documentation",
 ]
 
-timeout_sec = 3600
+timeout_sec = 10800

--- a/test/print_test.jl
+++ b/test/print_test.jl
@@ -24,6 +24,6 @@ end
     wait(test_print(CPU()))
     @test true
 
-    @print("Why this should work")
+    @print("Why this should work\n")
     @test true
 end


### PR DESCRIPTION
This makes the test suite output a little easier to read.