### PR TITLE
Adds cosd and sind to list of cudafuns

### DIFF
--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -285,16 +285,16 @@ KernelAbstractions.generate_overdubs(@__MODULE__, CUDACtx)
 @inline Cassette.overdub(::CUDACtx, ::typeof(^), x::Union{Float32, Float64}, y::Int64) = CUDA.pow(x, y)
 
 # libdevice.jl
-const cudafuns = (:cos, :cospi, :sin, :sinpi, :tan,
-          :acos, :asin, :atan,
-          :cosh, :sinh, :tanh,
-          :acosh, :asinh, :atanh,
-          :log, :log10, :log1p, :log2,
-          :exp, :exp2, :exp10, :expm1, :ldexp,
-          # :isfinite, :isinf, :isnan, :signbit,
-          :abs,
-          :sqrt, :cbrt,
-          :ceil, :floor,)
+const cudafuns = (:cos, :cospi, :cosd, :sin, :sinpi, :sind, :tan,
+                  :acos, :asin, :atan,
+                  :cosh, :sinh, :tanh,
+                  :acosh, :asinh, :atanh,
+                  :log, :log10, :log1p, :log2,
+                  :exp, :exp2, :exp10, :expm1, :ldexp,
+                  # :isfinite, :isinf, :isnan, :signbit,
+                  :abs,
+                  :sqrt, :cbrt,
+                  :ceil, :floor,)
 for f in cudafuns
     @eval function Cassette.overdub(ctx::CUDACtx, ::typeof(Base.$f), x::Union{Float32, Float64})
         @Base._inline_meta


### PR DESCRIPTION
cosd and sind are like cos and sin, except their arguments have units of "degrees" rather than radians.

Is there anything else I should do? Bump ~~minor~~ patch version for tagging purposes?