### PR TITLE
[CUDAKernels] add an implicit sync to kernels with no dependencies

### DIFF
--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -186,7 +186,7 @@ function threads_to_workgroupsize(threads, ndrange)
     end
 end
 
-function (obj::Kernel{CUDADevice})(args...; ndrange=nothing, dependencies=nothing, workgroupsize=nothing, progress=yield)
+function (obj::Kernel{CUDADevice})(args...; ndrange=nothing, dependencies=Event(CUDADevice()), workgroupsize=nothing, progress=yield)
 
     ndrange, workgroupsize, iterspace, dynamic = launch_config(obj, ndrange, workgroupsize)
     # this might not be the final context, since we may tune the workgroupsize

--- a/test/test.jl
+++ b/test/test.jl
@@ -221,7 +221,7 @@ if backend != CPU
         event1 = kernel_empty(backend(), 1)(ndrange=1)
         event2 = kernel_empty(backend(), 1)(ndrange=0; dependencies=event1)
         @test event2 == MultiEvent(event1)
-        event = kernel_empty(backend(), 1)(ndrange=0)
+        event = kernel_empty(backend(), 1)(ndrange=0, dependencies=nothing)
         @test event == MultiEvent(nothing)
     end
 end


### PR DESCRIPTION
Fixes #221, by placing synchronizing against the task local stream for kernels that are not
launched with dependencies. Maybe we should generally synchronize KA launches against the
task-local stream?

Also uses the task-local stream instead of the `CuDefaultStream`.
