### PR TITLE
avoid overdubbing of literal_pow

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -60,5 +60,7 @@ function generate_overdubs(Ctx)
             end
             Base.steprangelen_hp(T, start, step, 0, len, 1)
         end
+
+        @inline Cassette.overdub(::$Ctx, ::typeof(Base.literal_pow), f::F, x, p) where F = Base.literal_pow(f, x, p)
     end
 end

--- a/test/compiler.jl
+++ b/test/compiler.jl
@@ -12,3 +12,11 @@ iterspace = NDRange{1, StaticSize{(128,)}, StaticSize{(8,)}}();
 ctx = KernelAbstractions.mkcontext(kernel, 1, nothing, iterspace, Val(KernelAbstractions.NoDynamicCheck()))
 
 @test KernelAbstractions.Cassette.overdub(ctx, KernelAbstractions.__index_Global_NTuple, CartesianIndex(1)) == (1,)
+
+@kernel function literal_pow(A)
+    A[1] = 2^11
+end
+
+CI, rt = @ka_code_typed literal_pow(CPU())(zeros(Int,1), ndrange=1)
+# test that there is no invoke of overdub
+@test !any(stmt->(stmt isa Expr) && stmt.head == :invoke, CI.code)


### PR DESCRIPTION
fixes #223, of course this does not happen on 1.6

#JustCassetteThings

The issue seems to be the `generated` function used by `literal_pow`