### PR TITLE
nix overdub of _unsafe_getindex

### DIFF
--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -89,16 +89,5 @@ function generate_overdubs(mod, Ctx)
                 return k - Base.exponent_bias(T)
             end
         end
-
-        if VERSION >= v"1.6"
-            @inline function Cassette.overdub(::$Ctx, ::typeof(Base._unsafe_getindex), 
-                                              ::IndexStyle, A::AbstractArray, I::Vararg{Union{Real, AbstractArray}, N}) where N
-                shape = index_shape(I...)
-                dest = similar(A, shape)
-                map(unsafe_length, axes(dest)) == map(unsafe_length, shape) || throw(DimensionMismatch("output array is the wrong size"))
-                _unsafe_getindex!(dest, A, I...) 
-                return dest
-            end
-        end
     end
 end


### PR DESCRIPTION
bors r+

(cherry picked from commit 0c23a676c420e74c286674cc2a6d1b6cec40b263)
