### PR TITLE
Add AMD section to a couple of examples

### DIFF
--- a/examples/memcopy.jl
+++ b/examples/memcopy.jl
@@ -37,14 +37,6 @@ if has_cuda_gpu()
     @test A == B
 end
 
-function has_rocm_gpu()
-    for agent in AMDGPU.get_agents()
-        if agent.type == :gpu
-            return true
-        end
-    end
-    return false
-end
 
 if has_rocm_gpu()
 

--- a/examples/naive_transpose.jl
+++ b/examples/naive_transpose.jl
@@ -61,14 +61,6 @@ if has_cuda_gpu()
     @test a == transpose(b)
 end
 
-function has_rocm_gpu()
-    for agent in AMDGPU.get_agents()
-        if agent.type == :gpu
-            return true
-        end
-    end
-    return false
-end
 
 if has_rocm_gpu()
     d_a = ROCArray(a)


### PR DESCRIPTION
If AMDGPU.jl and ROCKernels.jl is mature enough then is it worth adding some AMD examples to the KernelAbstractions.jl examples?

This PR just tacks on an AMD example to the simplest example, `memcopy.jl`.

The `has_rocm_gpu` util doesn't belong here obviously (https://github.com/JuliaGPU/AMDGPU.jl/issues/158).

I guess there's some room for improvement since `mycopy!` is defined almost identically three times, but maybe being verbose here makes for a clearer example.

Hmmm, if AMD examples cannot be tested yet that would be a problem though.