### PR TITLE
fixing shmem line to match CUDA.jl

### DIFF
--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -326,7 +326,7 @@ import KernelAbstractions: ConstAdaptor, SharedMemory, Scratchpad, __synchronize
 ###
 
 @inline function Cassette.overdub(::CUDACtx, ::typeof(SharedMemory), ::Type{T}, ::Val{Dims}, ::Val{Id}) where {T, Dims, Id}
-    ptr = emit_shmem(Val(Id), T, Val(prod(Dims)))
+    ptr = emit_shmem(T, Val(prod(Dims)))
     CUDA.CuDeviceArray(Dims, ptr)
 end
 


### PR DESCRIPTION
This should fix any shared memory issues with KernelAbstractions; however, in the testing script, I had a convert from `Int64` -> `Int32` that caught #265 and potentially #254. I will post some findings there as well