### PR TITLE
using CPU as default for Scratchpad and SharedMemory

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -457,23 +457,8 @@ include("macros.jl")
 # Backends/Interface
 ###
 
-@inline function SharedMemory(::Type{T}, ::Val{Dims}, ::Val) where {T, Dims}
-    MArray{__size(Dims), T}(undef)
-end
-
-###
-# CPU implementation of scratch memory
-# - memory allocated as a MArray with size `Dims`
-###
-
-struct ScratchArray{N, D}
-    data::D
-    ScratchArray{N}(data::D) where {N, D} = new{N, D}(data)
-end
-
-@inline function Scratchpad(ctx, ::Type{T}, ::Val{Dims}) where {T, Dims}
-    return ScratchArray{length(Dims)}(MArray{__size((Dims..., prod(__groupsize(ctx)))), T}(undef))
-end
+function Scratchpad end
+function SharedMemory end
 
 function __synchronize()
     error("@synchronize used outside kernel or not captured")

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -198,6 +198,27 @@ end
     end
 end
 
+###
+# CPU implementation of shared memory
+###
+@inline function SharedMemory(::Type{T}, ::Val{Dims}, ::Val) where {T, Dims}
+    MArray{__size(Dims), T}(undef)
+end
+
+###
+# CPU implementation of scratch memory
+# - memory allocated as a MArray with size `Dims`
+###
+
+struct ScratchArray{N, D}
+    data::D
+    ScratchArray{N}(data::D) where {N, D} = new{N, D}(data)
+end
+
+@inline function Scratchpad(ctx, ::Type{T}, ::Val{Dims}) where {T, Dims}
+    return ScratchArray{length(Dims)}(MArray{__size((Dims..., prod(__groupsize(ctx)))), T}(undef))
+end
+
 # Base.view creates a boundscheck which captures A
 # https://github.com/JuliaLang/julia/issues/39308
 @inline function aview(A, I::Vararg{Any, N}) where N

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -198,27 +198,6 @@ end
     end
 end
 
-###
-# CPU implementation of shared memory
-###
-@inline function SharedMemory(::Type{T}, ::Val{Dims}, ::Val) where {T, Dims}
-    MArray{__size(Dims), T}(undef)
-end
-
-###
-# CPU implementation of scratch memory
-# - memory allocated as a MArray with size `Dims`
-###
-
-struct ScratchArray{N, D}
-    data::D
-    ScratchArray{N}(data::D) where {N, D} = new{N, D}(data)
-end
-
-@inline function Scratchpad(ctx, ::Type{T}, ::Val{Dims}) where {T, Dims}
-    return ScratchArray{length(Dims)}(MArray{__size((Dims..., prod(__groupsize(ctx)))), T}(undef))
-end
-
 # Base.view creates a boundscheck which captures A
 # https://github.com/JuliaLang/julia/issues/39308
 @inline function aview(A, I::Vararg{Any, N}) where N


### PR DESCRIPTION
I have been getting this error ever since #288 

```
[ Info: Precompiling KernelAbstractions [63c18a36-062a-441e-b654-da1e3ab1ce7c]
WARNING: Method definition SharedMemory(Type{T}, Base.Val{Dims}, Base.Val{x} where x) where {T, Dims} in module KernelAbstractions at /home/leios/projects/KernelAbstractions.jl/src/KernelAbstractions.jl:464 overwritten at /home/leios/projects/KernelAbstractions.jl/src/cpu.jl:204.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition Scratchpad(Any, Type{T}, Base.Val{Dims}) where {T, Dims} in module KernelAbstractions at /home/leios/projects/KernelAbstractions.jl/src/KernelAbstractions.jl:460 overwritten at /home/leios/projects/KernelAbstractions.jl/src/cpu.jl:218.
  ** incremental compilation may be fatally broken for this module **
```

I think it's because there used to be an overdub for ScratchPad and SharedMemory on the CPU with a default to an error message in KernelAbstractions, but now we are using `@device_override` and using the CPU versions as defaults.

This PR just moves the stuff in `cpu.jl` to `KernelAbstractions.jl`. There might be a better solution, so it's up to you what you want to do.