### PR TITLE
Make examples work by copy-paste into REPL

### DIFF
--- a/examples/histogram.jl
+++ b/examples/histogram.jl
@@ -1,7 +1,7 @@
 # INCLUDE ROCM
 using KernelAbstractions, Test
 using KernelAbstractions: @atomic, @atomicswap, @atomicreplace
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 
 
 # Function to use as a baseline for CPU metrics

--- a/examples/matmul.jl
+++ b/examples/matmul.jl
@@ -1,5 +1,5 @@
 using KernelAbstractions, Test
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 
 if has_cuda && has_cuda_gpu()
     CUDA.allowscalar(false)

--- a/examples/memcopy.jl
+++ b/examples/memcopy.jl
@@ -1,5 +1,5 @@
 using KernelAbstractions, Test
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 
 @kernel function copy_kernel!(A, @Const(B))
     I = @index(Global)

--- a/examples/memcopy_static.jl
+++ b/examples/memcopy_static.jl
@@ -1,5 +1,5 @@
 using KernelAbstractions, Test
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 
 @kernel function copy_kernel!(A, @Const(B))
     I = @index(Global)

--- a/examples/naive_transpose.jl
+++ b/examples/naive_transpose.jl
@@ -1,5 +1,5 @@
 using KernelAbstractions, Test
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 
 if has_cuda && has_cuda_gpu()
     CUDA.allowscalar(false)

--- a/examples/performance.jl
+++ b/examples/performance.jl
@@ -1,5 +1,5 @@
 using KernelAbstractions, Test
-include(joinpath(@__DIR__, "utils.jl")) # Load backend
+include(joinpath(dirname(pathof(KernelAbstractions)), "../examples/utils.jl")) # Load backend
 using KernelAbstractions.Extras: @unroll
 
 has_cuda && has_cuda_gpu() || exit()


### PR DESCRIPTION
This is a one line change in the examples files to make the inclusion of the `examples/utils.jl` file more robust.

The outcome is that these files now work if copy-pasted into the REPL.