### PR TITLE
[doc] Some revamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ KernelAbstractions.jl
 ==============
 KernelAbstractions (KA) is
 a package that enables you to write GPU-like kernels targetting different
-execution [backends](backends.md). KA is intended to be a minimal and
+execution backends. KA is intended to be a minimal and
 performant library that explores ways to write heterogeneous code.
 Currently, the following backends are supported:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 KernelAbstractions.jl
 ==============
-*Ash dushum durbatulûk, ash dushum gimbatul, ash dushum thrakatulûk, agh burzum-ishi krimpatul*
+KernelAbstractions (KA) is
+a package that enables you to write GPU-like kernels targetting different
+execution [backends](backends.md). KA is intended to be a minimal and
+performant library that explores ways to write heterogeneous code.
+Currently, the following backends are supported:
+
+* [NVIDIA CUDA](https://github.com/JuliaGPU/CUDA.jl),
+* [AMD ROCm](https://github.com/JuliaGPU/AMDGPU.jl),
+* [Intel oneAPI](https://github.com/JuliaGPU/oneAPI.jl).
 
 [![Documentation (stable)][docs-stable-img]][docs-stable-url]
 [![Documentation (latest)][docs-latest-img]][docs-latest-url]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -13,6 +13,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Quickstart" => "quickstart.md",
         "Writing kernels" => "kernels.md",
         "Examples" => [
             "examples/memcopy.md",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,6 +9,8 @@
 @localmem
 @private
 @synchronize
+@print
+@uniform
 groupsize
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,10 +13,9 @@ systems. Currently, profiling and debugging require backend-specific calls like,
 [`CUDA.jl`](https://cuda.juliagpu.org/dev/development/profiling/).
 
 !!! note
-    While `KernelAbstraction.jl` focuses on performance portability, it
-    currently remains GPU-biased.
-    Therefore, the kernel language requires several specific constructs for good GPU
-    performance but may hurt CPU performance.
+While KernelAbstraction.jl is focused on performance portability, it emulates GPU semantics and therefore the kernel language has several constructs that are necessary for good performance on the GPU, but serve no purpose on the CPU.
+In these cases, we either ignore such statements entirely (such as with `@synchronize`) or swap out the construct for something similar on the CPU (such as using an `MVector`  to replace `@localmem`).
+This means that CPU performance will still be fast, but might be performing extra work to provide a consistent programming model across GPU and CPU
 
 ## Supported backends
 All supported backends rely on their respective Julia interface to the compiler

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,9 +7,8 @@ performant
 library that explores ways to write heterogeneous code. Although parts of
 the package are still experimental, it has been used successfully as part of the
 Exascale Computing Project to run Julia code on pre-Frontier and pre-Aurora
-systems. Currently missing from the documentation is
- * how to debug kernels, and
- * how to profile kernels.
+systems. Currently, profiling and debugging require backend-specific calls like, for example, in
+[`CUDA.jl`](https://cuda.juliagpu.org/dev/development/profiling/).
 
 !!! note
     While `KernelAbstraction.jl` focuses on performance portability, it

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,9 @@ execution backends. KA intends to be a minimal and
 performant
 library that explores ways to write heterogeneous code. Although parts of
 the package are still experimental, it has been used successfully as part of the
-Exascale Computing Project to run Julia code on pre-Frontier and pre-Aurora
+[Exascale Computing Project](https://www.exascaleproject.org/) to run Julia code
+on pre-[Frontier](https://www.olcf.ornl.gov/frontier/) and
+pre-[Aurora](https://www.alcf.anl.gov/aurora)
 systems. Currently, profiling and debugging require backend-specific calls like, for example, in
 [`CUDA.jl`](https://cuda.juliagpu.org/dev/development/profiling/).
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,91 +1,75 @@
 # KernelAbstractions
 
-`KernelAbstractions.jl` is a package that allows you to write GPU-like kernels that
-target different execution backends. It is intended to be a minimal, and performant
-library that explores ways to best write heterogenous code.
+[`KernelAbstractions.jl`](https://github.com/JuliaGPU/KernelAbstractions.jl) (KA) is
+a package that allows you to write GPU-like kernels targetting different
+execution backends. KA intends to be a minimal and
+performant
+library that explores ways to write heterogeneous code. Although parts of
+the package are still experimental, it has been used successfully as part of the
+Exascale Computing Project to run Julia code on pre-Frontier and pre-Aurora
+systems. Currently missing from the documentation is
+ * how to debug kernels, and
+ * how to profile kernels.
 
 !!! note
-    While `KernelAbstraction.jl` is focused on performance portability, it is GPU-biased
-    and therefore the kernel language has several constructs that are necessary for good
-    performance on the GPU, but may hurt performance on the CPU.
+    While `KernelAbstraction.jl` focuses on performance portability, it
+    currently remains GPU-biased.
+    Therefore, the kernel language requires several specific constructs for good GPU
+    performance but may hurt CPU performance.
 
-## Quickstart
-
-### Writing your first kernel
-
-Kernel functions have to be marked with the [`@kernel`](@ref). Inside the `@kernel` macro
-you can use the [kernel language](@ref api_kernel_language). As an example the `mul2` kernel
-below will multiply each element of the array `A` by `2`. It uses the [`@index`](@ref) macro
-to obtain the global linear index of the current workitem.
-
+## Supported backends
+All supported backends rely on their respective Julia interface to the compiler
+backend and depend on
+[`GPUArrays.jl`](https://github.com/JuliaGPU/GPUArrays.jl) and
+[`GPUCompiler.jl`](https://github.com/JuliaGPU/GPUCompiler.jl). KA provides
+interface kernel generation modules to those packages in
+[`/lib`](https://github.com/JuliaGPU/KernelAbstractions.jl/tree/master/lib).
+After loading the kernel packages, KA will provide a `KA.Device` for that
+backend to be used in the kernel generation stage.
+### CUDA
 ```julia
-@kernel function mul2(A)
-  I = @index(Global)
-  A[I] = 2 * A[I]
-end
+using CUDA
+using KernelAbstractions
+using CUDAKernels
 ```
-
-### Launching your first kernel
-
-You can construct a kernel for a specific backend by calling the kernel function
-with the first argument being the device kind, the second argument being the size
-of the workgroup and the third argument being a static `ndrange`. The second and
-third argument are optional. After instantiating the kernel you can launch it by
-calling the kernel object with the right arguments and some keyword arguments that
-configure the specific launch. The example below creates a kernel with a static
-workgroup size of `16` and a dynamic `ndrange`. Since the `ndrange` is dynamic it
-has to be provided for the launch as a keyword argument.
-
+[`CUDA.jl`](https://github.com/JuliaGPU/CUDA.jl) is currently the most mature way to program for GPUs.
+This provides a device `CUDADevice <: KA.Device` to
+### AMDGPU
 ```julia
-A = ones(1024, 1024)
-kernel = mul2(CPU(), 16)
-event = kernel(A, ndrange=size(A))
-wait(event)
-all(A .== 2.0)
+using AMDGPU
+using KernelAbstractions
+using ROCKernels
 ```
+Experimental AMDGPU (ROCm) support is available via the
+[`AMDGPU.jl`](https://github.com/JuliaGPU/AMDGPU.jl) and `ROCKernels.jl`. It
+provides the device `ROCDevice <: KA.Device`. Please get in touch with `@jpsamaroo` for
+any issues specific to the ROCKernels backend.
+###  oneAPI
+Experimental support for Intel GPUs has also been added through the oneAPI Intel
+Compute Runtime interfaced to in
+[`oneAPI.jl`](https://github.com/JuliaGPU/oneAPI.jl)
 
-!!! danger
-    All kernel launches are asynchronous, each kernel produces an event token that
-    has to be waited upon, before reading or writing memory that was passed as an
-    argument to the kernel. See [dependencies](@ref dependencies) for a full
-    explanation.
+## Semantic differences
 
-If you have a GPU attached to your machine, it's equally as easy to launch your
-kernel on it instead. For example, launching on a CUDA GPU:
-
-```julia
-using CUDAKernels # Required to access CUDADevice
-A = CUDA.ones(1024, 1024)
-kernel = mul2(CUDADevice(), 16)
-# ... the rest is the same!
-```
-
-AMDGPU (ROCm) support is also available via the ROCKernels.jl package, although
-at this time it is considered experimental. Ping `@jpsamaroo` in any issues
-specific to the ROCKernels backend.
-
-## Important differences to Julia
+### To Julia
 
 1. Functions inside kernels are forcefully inlined, except when marked with `@noinline`.
 2. Floating-point multiplication, addition, subtraction are marked contractable.
 
-## Important differences to CUDA.jl/AMDGPU.jl
+### To CUDA.jl/AMDGPU.jl
 
 1. The kernels are automatically bounds-checked against either the dynamic or statically
    provided `ndrange`.
 2. Functions like `Base.sin` are mapped to `CUDA.sin`/`AMDGPU.sin`.
 
-## Important differences to GPUifyLoops.jl
+### To GPUifyLoops.jl
 
 1. `@scratch` has been renamed to `@private`, and the semantics have changed. Instead
    of denoting how many dimensions are implicit on the GPU, you only ever provide the
    explicit number of dimensions that you require. The implicit CPU dimensions are
    appended.
 
-## How to debug kernels
-
-*TODO*
-
-## How to profile kernels
-
-*TODO*
+## Contributing
+Please file any bug reports through Github issues or fixes through a pull
+request. Any heterogeneous hardware or code aficionados is welcome to join us on
+our journey.

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -44,16 +44,33 @@ This implies that the host will launch no new kernels on any device until the
 wait returns.
 ## Launching kernel on the device
 
-To launch the kernel on a CUDA-supported GPU, we generate the kernel
-for the device of type `CUDADevice` provided by `CUDAKernels` (see [backends](backends.md)).
+To launch the kernel on a backend-supported device `isa(device, KA.GPU)` (e.g., `CUDADevice()`, `ROCDevice()`, `oneDevice()`), we generate the kernel
+for this device provided by `CUDAKernels`, `ROCKernels`, or `oneAPIKernels` (see [backends](backends.md)).
+
+First, we initialize the array using the Array constructor of the chosen device with
 
 ```julia
 using CUDAKernels # Required to access CUDADevice
-A = CUDA.ones(1024, 1024)
-ev = mul2_kernel(CUDADevice(), 16)(A, ndrange=size(A))
+A = CuArray(ones(1024, 1024))
+```
+
+```julia
+using ROCKernels # Required to access CUDADevice
+A = ROCArray(ones(1024, 1024))
+```
+
+```julia
+using oneAPIKernels # Required to access CUDADevice
+A = oneArray(ones(1024, 1024))
+```
+The kernel generation and execution are then
+```julia
+ev = mul2_kernel(device, 16)(A, ndrange=size(A))
 wait(ev)
 all(A .== 2.0)
 ```
+
+For simplicity, we stick with the case of `device=CUDADevice()`.
 
 ## Synchronization
 !!! danger

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart
+
+## Writing your first kernel
+
+Kernel functions are marked with the [`@kernel`](@ref). Inside the `@kernel` macro
+you can use the [kernel language](@ref api_kernel_language). As an example, the `mul2`` kernel
+below will multiply each element of the array `A` by `2`. It uses the [`@index`](@ref) macro
+to obtain the global linear index of the current work item.
+
+```julia
+@kernel function mul2_kernel(A)
+  I = @index(Global)
+  A[I] = 2 * A[I]
+end
+```
+
+## Launching kernel on the host
+
+You can construct a kernel for a specific backend by calling the kernel function
+with the first argument being the device of type `KA.Device`, the second argument being the size
+of the workgroup and the third argument being a static `ndrange`. The second and
+third argument are optional. After instantiating the kernel you can launch it by
+calling the kernel object with the right arguments and some keyword arguments that
+configure the specific launch.
+
+```julia
+A = ones(1024, 1024)
+ev = mul2_kernel(CPU(), 16)(A, ndrange=size(A))
+wait(ev)
+all(A .== 2.0)
+```
+`mul_kernel(CPU(), 16)` creates a kernel for the host device `CPU()` with a static
+workgroup size of `16` and a dynamic `ndrange`. This returns a kernel that is launched with the inputs
+and the dynamic `ndrange` as a keyword argument via `kernel(A,
+ndrange=size(A))`. All of this is reduced to one line of code with the kernel
+eventually returning an event `ev`. All kernels are launched asynchronously,
+thus event `ev` specifies the current state of the execution.
+The [`wait`] blocks the *host* until the event `ev` has completed on the device. This implies
+that no new kernels will be launched by the host on any device until the wait is completed.
+## Launching kernel on the device
+
+To launch the kernel on a CUDA supported GPU we just have to generate the kernel
+for the device of type `CUDADevice` provided by `CUDAKernels` (see [backends](backends.md)).
+
+```julia
+using CUDAKernels # Required to access CUDADevice
+A = CUDA.ones(1024, 1024)
+ev = mul2_kernel(CUDADevice(), 16)(A, ndrange=size(A))
+wait(ev)
+all(A .== 2.0)
+```
+
+## Synchronization
+!!! danger
+    All kernel launches are asynchronous, each kernel produces an event token that
+    has to be waited upon, before reading or writing memory that was passed as an
+    argument to the kernel. See [dependencies](@ref dependencies) for a full
+    explanation.
+
+The code around KA may heavily rely on
+[`GPUArrays`](https://github.com/JuliaGPU/GPUArrays.jl), for example, to
+intialize variables.
+```julia
+using CUDAKernels # Required to access CUDADevice
+function mymul(A::CuArray)
+    A .= 1.0
+    ev = mul2_kernel(CUDADevice(), 16)(A, ndrange=size(A))
+    wait(ev)
+    all(A .== 2.0)
+end
+```
+
+These statement-level generated kernels like `A .= 1.0` are executed on a
+different stream as the KA kernels.  Launching `mul_kernel` may start before `A
+.= 1.0` has completed. To prevent this, we add a device-wide dependency to the
+kernel by adding `dependencies=Event(CUDADevice())`.
+```julia
+ev = mul_kernel(CUDADevice(), 16)(A, ndrange=size(A), dependencies=Event(CUDADevice()))
+```
+This device dependency requires all kernels on the device to be compeleted before this kernel is launched.
+In the same vain, multiple events may be added to a wait.
+
+```julia
+using CUDAKernels # Required to access CUDADevice
+function mymul(A::CuArray, B::CuArray)
+    A .= 1.0
+    B .= 3.0
+    evA = mul2_kernel(CUDADevice(), 16)(A, ndrange=size(A), dependencies=Event(CUDADevice()))
+    evB = mul2_kernel(CUDADevice(), 16)(A, ndrange=size(A), dependencies=Event(CUDADevice()))
+    wait(evA, evB)
+    all(A .+ B .== 8.0)
+end
+```

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -45,7 +45,7 @@ wait returns.
 ## Launching kernel on the device
 
 To launch the kernel on a backend-supported device `isa(device, KA.GPU)` (e.g., `CUDADevice()`, `ROCDevice()`, `oneDevice()`), we generate the kernel
-for this device provided by `CUDAKernels`, `ROCKernels`, or `oneAPIKernels` (see [backends](backends.md)).
+for this device provided by `CUDAKernels`, `ROCKernels`, or `oneAPIKernels`.
 
 First, we initialize the array using the Array constructor of the chosen device with
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -1,8 +1,8 @@
 # Quickstart
 
 ## Terminology
-CUDA being the most popular GPU programming environment, we take it as a
-reference for defining terminology in KA. A *workgroup is called a block in
+Because CUDA is the most popular GPU programming environment, we can use it as a
+reference for defining terminology in KA. A *workgroup* is called a block in
 NVIDIA CUDA and designates a group of threads acting in parallel, preferably
 in lockstep. For the GPU, the workgroup size is typically around 256, while for the CPU,
 it is usually less than or equal to the number of CPU cores. An *ndrange* is

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -13,7 +13,7 @@ number of items to iterate over in a loop.
 ## Writing your first kernel
 
 Kernel functions are marked with the [`@kernel`](@ref). Inside the `@kernel` macro
-you can use the [kernel language](@ref api_kernel_language). As an example, the `mul2`` kernel
+you can use the [kernel language](@ref api_kernel_language). As an example, the `mul2` kernel
 below will multiply each element of the array `A` by `2`. It uses the [`@index`](@ref) macro
 to obtain the global linear index of the current work item.
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -16,12 +16,13 @@ end
 
 ## Launching kernel on the host
 
-You can construct a kernel for a specific backend by calling the kernel function
-with the first argument being the device of type `KA.Device`, the second argument being the size
+You can construct a kernel for a specific backend by calling the kernel
+function, with the first argument being the device of type `KA.Device`, the
+second argument being the size
 of the workgroup and the third argument being a static `ndrange`. The second and
-third argument are optional. After instantiating the kernel you can launch it by
-calling the kernel object with the right arguments and some keyword arguments that
-configure the specific launch.
+third arguments are optional. After instantiating the kernel, you can launch it by
+calling the kernel object with these arguments and some keyword arguments
+configuring the specific launch.
 
 ```julia
 A = ones(1024, 1024)
@@ -30,16 +31,15 @@ wait(ev)
 all(A .== 2.0)
 ```
 `mul_kernel(CPU(), 16)` creates a kernel for the host device `CPU()` with a static
-workgroup size of `16` and a dynamic `ndrange`. This returns a kernel that is launched with the inputs
-and the dynamic `ndrange` as a keyword argument via `kernel(A,
-ndrange=size(A))`. All of this is reduced to one line of code with the kernel
-eventually returning an event `ev`. All kernels are launched asynchronously,
-thus event `ev` specifies the current state of the execution.
-The [`wait`] blocks the *host* until the event `ev` has completed on the device. This implies
-that no new kernels will be launched by the host on any device until the wait is completed.
+workgroup size of `16` and a dynamic `ndrange`. This function returns a kernel launched with the inputs
+and the dynamic `ndrange` as a keyword argument via `kernel(A,ndrange=size(A))`.
+The kernel
+eventually returning an event `ev`. All kernels are launched asynchronously.
+Thus, event `ev` specifies the current state of the execution.
+The [`wait`] blocks the *host* until the event `ev` has completed on the device. This implies that the host will launch no new kernels on any device until the wait returns.
 ## Launching kernel on the device
 
-To launch the kernel on a CUDA supported GPU we just have to generate the kernel
+To launch the kernel on a CUDA supported GPU we generate the kernel
 for the device of type `CUDADevice` provided by `CUDAKernels` (see [backends](backends.md)).
 
 ```julia
@@ -71,13 +71,13 @@ end
 ```
 
 These statement-level generated kernels like `A .= 1.0` are executed on a
-different stream as the KA kernels.  Launching `mul_kernel` may start before `A
+different stream than the KA kernels.  Launching `mul_kernel` may start before `A
 .= 1.0` has completed. To prevent this, we add a device-wide dependency to the
 kernel by adding `dependencies=Event(CUDADevice())`.
 ```julia
 ev = mul_kernel(CUDADevice(), 16)(A, ndrange=size(A), dependencies=Event(CUDADevice()))
 ```
-This device dependency requires all kernels on the device to be compeleted before this kernel is launched.
+This device dependency requires all kernels on the device to be completed before this kernel is launched.
 In the same vain, multiple events may be added to a wait.
 
 ```julia


### PR DESCRIPTION
A minor pass over the docs.

* List backends
* Updated README.md addressing https://github.com/JuliaGPU/KernelAbstractions.jl/issues/302
* Moved quickstart to its own page and expand. Added explicit synchronization section (to be expanded).

@vchuravy I am still not sure about the synchronization. In particular, the quickstart example does
```julia
A = ones(1024, 1024)
ev = mul2_kernel(CPU(), 16)(A, ndrange=size(A))
```
With `A .= 1.0` I am sure we ran into issues where that generated kernel was not completed when the KA kernel was launched. So we had to add `dependencies=Event(CUDADevice())`. How about `A = ones(1024,1024)`?