### PR TITLE
updating ROCKernels to AMDGPU v0.4.1

### DIFF
--- a/lib/ROCKernels/Project.toml
+++ b/lib/ROCKernels/Project.toml
@@ -11,9 +11,9 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UnsafeAtomicsLLVM = "d80eeb9a-aca5-4d75-85e5-170c8b632249"
 
 [compat]
-AMDGPU = "0.3.2"
+AMDGPU = "0.4.1"
 Adapt = "3.0"
 KernelAbstractions = "0.8"
 StaticArrays = "0.12, 1.0"
-julia = "1.7"
 UnsafeAtomicsLLVM = "0.1"
+julia = "1.7"


### PR DESCRIPTION
This should update ROCKernels to the latest AMDGPU.

This is necessary because otherwise AMDGPU is pinning CUDA at v 3.9.1 and causing the following build error: https://github.com/JuliaGPU/CUDA.jl/pull/1558

I realized after the update that `ROCDevice` is now potentially conflicting with `AMDGPU.ROCDevice`.