### PR TITLE
setting ndrange macro to output a Tuple

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -144,7 +144,7 @@ a tuple corresponding to kernel configuration.
 """
 macro ndrange()
     quote
-        $ndrange($(esc(:__ctx__)))
+        $size($ndrange($(esc(:__ctx__))))
     end 
 end
 


### PR DESCRIPTION
This makes it so the `@ndrange()` macro outputs a tuple instead of `CartesianIndex{1}[CartesianIndex(1,),....]` As seen in #329 