### PR TITLE
[ROCKernels] Import LLVM

### DIFF
--- a/lib/ROCKernels/src/ROCKernels.jl
+++ b/lib/ROCKernels/src/ROCKernels.jl
@@ -6,7 +6,7 @@ import StaticArrays
 import StaticArrays: MArray
 import Adapt
 import KernelAbstractions
-
+import LLVM
 import UnsafeAtomicsLLVM
 
 export ROCDevice


### PR DESCRIPTION
Otherwise `@Const` results in Invalid IR since transition to `LLVM.Interop.addrspacecast`.