### PR TITLE
Introducing @reduce for group level reduction

### DIFF
--- a/lib/CUDAKernels/src/CUDAKernels.jl
+++ b/lib/CUDAKernels/src/CUDAKernels.jl
@@ -411,8 +411,7 @@ KernelAbstractions.argconvert(k::Kernel{<:CUDADevice}, arg) = CUDA.cudaconvert(a
 
 # TODO: make variable block size possible
 # TODO: figure out where to place this
-
-# group reduce that uses warp level reduction
+# reduction functionality for a group
 @device_override @inline function __reduce(__ctx__ , op, val, neutral, ::Type{T}) where T
     threads = KernelAbstractions.@groupsize()[1]
     threadIdx = KernelAbstractions.@index(Local)

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -4,6 +4,7 @@ export @kernel
 export @Const, @localmem, @private, @uniform, @synchronize
 export @index, @groupsize, @ndrange
 export @print
+export @reduce
 export Device, GPU, CPU, Event, MultiEvent, NoneEvent
 export async_copy!
 
@@ -329,6 +330,14 @@ macro index(locale, args...)
     Expr(:call, GlobalRef(KernelAbstractions, index_function), esc(:__ctx__), map(esc, args)...)
 end
 
+# TODO: Where should we havdle the logic of neutral, adding it to the macro's logic would reduce complexity in terms of using the macro
+# but adding it to the macro may cause some overhead
+macro reduce(op, val)
+    quote
+        $__reduce($(esc(op)), $(esc(val)), typeof($(esc(val))))
+    end
+end
+
 ###
 # Internal kernel functions
 ###
@@ -493,6 +502,7 @@ function __synchronize()
     error("@synchronize used outside kernel or not captured")
 end
 
+
 @generated function __print(items...)
     str = ""
     args = []
@@ -514,6 +524,14 @@ end
 # Utils
 __size(args::Tuple) = Tuple{args...}
 __size(i::Int) = Tuple{i}
+
+
+# reduction
+function __reduce(op, val, ::Type{T}) where T
+    error("@reduce used outside kernel or not captured")
+end
+
+
 
 ###
 # Extras

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -332,9 +332,9 @@ end
 
 # TODO: Where should we havdle the logic of neutral, adding it to the macro's logic would reduce complexity in terms of using the macro
 # but adding it to the macro may cause some overhead
-macro reduce(op, val)
+macro reduce(op, val, neutral)
     quote
-        $__reduce($(esc(op)), $(esc(val)), typeof($(esc(val))))
+        $__reduce($(esc(:__ctx__)),$(esc(op)), $(esc(val)), $(esc(neutral)), typeof($(esc(val))))
     end
 end
 
@@ -530,8 +530,6 @@ __size(i::Int) = Tuple{i}
 function __reduce(op, val, ::Type{T}) where T
     error("@reduce used outside kernel or not captured")
 end
-
-
 
 ###
 # Extras

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -330,11 +330,15 @@ macro index(locale, args...)
     Expr(:call, GlobalRef(KernelAbstractions, index_function), esc(:__ctx__), map(esc, args)...)
 end
 
-# TODO: Where should we havdle the logic of neutral, adding it to the macro's logic would reduce complexity in terms of using the macro
-# but adding it to the macro may cause some overhead
 macro reduce(op, val, neutral)
     quote
         $__reduce($(esc(:__ctx__)),$(esc(op)), $(esc(val)), $(esc(neutral)), typeof($(esc(val))))
+    end
+end
+
+macro test(conf)
+    quote
+        $__test($(esc(:__ctx__)),$(esc(conf)))
     end
 end
 
@@ -527,8 +531,12 @@ __size(i::Int) = Tuple{i}
 
 
 # reduction
-function __reduce(op, val, ::Type{T}) where T
+function __reduce(__ctx__, op, val, ::Type{T}) where T
     error("@reduce used outside kernel or not captured")
+end
+
+function __test(__ctx__, conf)
+    error("@test used outside kernel or not captured")
 end
 
 ###
@@ -536,9 +544,12 @@ end
 # - LoopInfo
 ###
 
+
 include("extras/extras.jl")
 
 include("reflection.jl")
+
+include("reduce.jl")
 
 # CPU backend
 

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -1,0 +1,52 @@
+struct Config{
+    THREADS_PER_WARP,         # size of warp 
+    THREADS_PER_BLOCK         # size of blocks
+   }
+end
+
+@inline function Base.getproperty(conf::Type{Config{ THREADS_PER_WARP, THREADS_PER_BLOCK}}, sym::Symbol) where { THREADS_PER_WARP, THREADS_PER_BLOCK}
+    if sym == :threads_per_warp
+        THREADS_PER_WARP
+    elseif sym == :threads_per_block
+        THREADS_PER_BLOCK
+    else
+        # fallback for nothing
+        getfield(conf, sym)
+    end
+end
+
+# TODO: make variable block size possible
+# TODO: figure out where to place this
+# reduction functionality for a group
+@inline function __reduce(__ctx__ , op, val, neutral, ::Type{T}) where {T}
+    threads = KernelAbstractions.@groupsize()[1]
+    threadIdx = KernelAbstractions.@index(Local)
+
+    # shared mem for a complete reduction
+    shared = KernelAbstractions.@localmem(T, 1024)
+    @inbounds shared[threadIdx] = val
+
+    # perform the reduction
+    d = 1
+    while d < threads
+        KernelAbstractions.@synchronize()
+        index = 2 * d * (threadIdx-1) + 1
+        @inbounds if index <= threads
+            other_val = if index + d <= threads
+                shared[index+d]
+            else
+                neutral
+            end
+            shared[index] = op(shared[index], other_val)
+        end
+        d *= 2
+    end
+
+    # load the final value on the first thread
+    if threadIdx == 1
+        val = @inbounds shared[threadIdx]
+    end
+
+    # every thread will return the reduced value of the group
+    return val
+end


### PR DESCRIPTION
The @reduce macro performs a group level reduction. 

TODOs:
- Figure out a place for the implementation.
- Add a lane level reduction.
- Create a more advanced group level reduction that is able to utilize platform dependant feature such as lane reduction and  atomics.