### PR TITLE
Improve clarity of numa_aware example

### DIFF
--- a/examples/numa_aware.jl
+++ b/examples/numa_aware.jl
@@ -53,6 +53,6 @@ end
 measure_membw(CPU());
 measure_membw(CPU(; static=true));
 
-# The following has siginifcantly worse performance (even on systems with a single memory domain)!
+# The following has significantly worse performance (even on systems with a single memory domain)!
 # measure_membw(CPU(); init=:serial);
 # measure_membw(CPU(; static=true); init=:serial);


### PR DESCRIPTION
```
Memory Bandwidth (GB/s): 145.64
Compute (GFLOP/s): 24.27

Memory Bandwidth (GB/s): 333.83
Compute (GFLOP/s): 55.64

Memory Bandwidth (GB/s): 32.74
Compute (GFLOP/s): 5.46

Memory Bandwidth (GB/s): 32.46
Compute (GFLOP/s): 5.41
```

(Can be merged IMO)