### PR TITLE
Update the quickstart documentation.

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,7 +25,7 @@ backend and depend on
 
 ### CUDA
 ```julia
-using CUDA
+import CUDA
 using KernelAbstractions
 ```
 [`CUDA.jl`](https://github.com/JuliaGPU/CUDA.jl) is currently the most mature way to program for GPUs.


### PR DESCRIPTION
Update the quickstart documentation so it can be run with the current version of KernelAbstractions.