### PR TITLE
Update to Documenter v1

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "~0.24"
+Documenter = "1"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,6 +3,8 @@ push!(Base.LOAD_PATH, dirname(@__DIR__))
 using KernelAbstractions
 using Documenter
 
+const ci = get(ENV, "CI", "") == "true"
+
 makedocs(;
     modules=[KernelAbstractions],
     authors="JuliaGPU and contributors",
@@ -13,6 +15,7 @@ makedocs(;
         canonical="https://juliagpu.github.io/KernelAbstractions.jl",
         assets=String[],
     ),
+    warnonly=[:missing_docs],
     pages=[
         "Home" => "index.md",
         "Quickstart" => "quickstart.md",
@@ -33,6 +36,8 @@ makedocs(;
     ], # pages
 )
 
-deploydocs(;
-    repo="github.com/JuliaGPU/KernelAbstractions.jl",
-)
+if ci
+    deploydocs(;
+        repo="github.com/JuliaGPU/KernelAbstractions.jl",
+    )
+end

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -13,13 +13,19 @@
 @uniform
 @groupsize
 @ndrange
+synchronize
 ```
 
-## Host interface
+## Host language
+
+```@docs
+KernelAbstractions.zeros
+```
 
 ## Internal
 
 ```@docs
 KernelAbstractions.Kernel
 KernelAbstractions.partition
+KernelAbstractions.@context
 ```

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -570,6 +570,9 @@ workgroupsize(::Kernel{D, WorkgroupSize}) where {D, WorkgroupSize} = WorkgroupSi
 ndrange(::Kernel{D, WorkgroupSize, NDRange}) where {D, WorkgroupSize,NDRange} = NDRange
 backend(kernel::Kernel) = kernel.backend
 
+"""
+Partition a kernel for the given ndrange and workgroupsize.
+"""
 @inline function partition(kernel, ndrange, workgroupsize)
     static_ndrange = KernelAbstractions.ndrange(kernel)
     static_workgroupsize = KernelAbstractions.workgroupsize(kernel)


### PR DESCRIPTION
Looks fine locally, so should be ready.

**Comments**
* I modified `docs/src/api.md` a little bit to fix Documenter errors. Please rearrange things or relabel sections if necessary (the structure isn't entirely clear to me, i.e. what is internal what not etc.). I feel this could need some more love anyways.
* I marked missing docstrings as `warnonly` (was also the case for the old Documenter version) instead of erroring (new behavior). Frankly because I didn't want to add docstrings for all theses things right now :)

cc @vchuravy 