### PR TITLE
Change 'A to B' -> 'B to A' in memcopy descriptions

### DIFF
--- a/docs/src/examples/memcopy.md
+++ b/docs/src/examples/memcopy.md
@@ -1,6 +1,6 @@
 # Memcopy
 
-The first example simple copies memory from `A` to `B`
+The first example simple copies memory from `B` to `A`
 
 ````@eval
 using Markdown

--- a/docs/src/examples/memcopy_static.md
+++ b/docs/src/examples/memcopy_static.md
@@ -1,6 +1,6 @@
 # Memcopy with static NDRange
 
-The first example simple copies memory from `A` to `B`. In contrast to the previous examples
+The first example simple copies memory from `B` to `A`. In contrast to the previous examples
 it uses a fully static kernel configuration. Specializing the kernel on the iteration range itself.
 
 ````@eval


### PR DESCRIPTION
Fixes an inconsistency in the `memcopy` examples