### PR TITLE
adding attempt to force inbounds at the kernel level

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -10,10 +10,16 @@ function find_return(stmt)
 end
 
 # XXX: Proper errors
-function __kernel(expr, generate_cpu=true)
+function __kernel(expr, generate_cpu=true, force_inbounds=false)
     def = splitdef(expr)
     name = def[:name]
     args = def[:args]
+    if force_inbounds
+        body_qt = quote
+            @inbounds $(def[:body])
+        end
+        def[:body] = body_qt
+    end
 
     find_return(expr) && error("Return statement not permitted in a kernel function $name")
 


### PR DESCRIPTION
This adds an additional flag at the `@kernel` level to force `@inbounds` across the entire kernel. It works like:

```
julia> @kernel inbounds=true function check_inline(a)
           a[5] = 5
       end
julia> a = [0,0];
julia> backend = get_backend(a);
julia> kernel! = check_inline(backend, 256);
julia> kernel!(a, ndrange = 10) # no error!
```

Note that this comes with all the caveats of using `@inbounds` and is certainly not good for default behaviour, but... Geez I'm tired of all the `@inbounds`

I'll rebase and add some tests soon if people think this could be useful.