### PR TITLE
Add `<0.0.1` compat for all stdlibs outside of julia repo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,8 +29,8 @@ UnsafeAtomics = "0.2.1"
 UnsafeAtomicsLLVM = "0.1"
 InteractiveUtils = "1.6"
 LinearAlgebra = "1.6"
-SparseArrays = "1.6"
-UUIDs = "1.6"
+SparseArrays = "<0.0.1, 1.6"
+UUIDs = "<0.0.1, 1.6"
 julia = "1.6"
 
 [extensions]


### PR DESCRIPTION
This is remedy with the issue described by @KristofferC on [Slack](https://julialang.slack.com/archives/C6M4DQA5P/p1698677496065029?thread_ts=1698485236.571999&cid=C6M4DQA5P):
> For posterity, the bug with the 0.0.0 is as follows:
> 1. When testing, Pkg rewrites the stdlib entries to actually be devved, this was needed before https://github.com/JuliaLang/julia/pull/39572 to be able to find stdlibs even if @stdlib was not in the path
> 2. Pkg was inconsistent between what version it assigned stdlibs that had no explicit version entry in them. In one place, it gave them version 0.0.0 (https://github.com/JuliaLang/Pkg.jl/blob/e79cb868f7f3c43cdffb5f462a4c21c8ae772eb4/src/Operations.jl#L261) and in another it gave them VERSION (https://github.com/JuliaLang/Pkg.jl/blob/e79cb868f7f3c43cdffb5f462a4c21c8ae772eb4/src/Operations.jl#L507)
> 3. So when doing Pkg operations inside a Pkg.test the stdlibs are devved and get version 0.0.0 which are incompatible with the VERSION entries they are assigned to in other places.
