### PR TITLE
Add `allocate` to docs

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -14,6 +14,7 @@
 @groupsize
 @ndrange
 synchronize
+allocate
 ```
 
 ## Host language


### PR DESCRIPTION
Missing from the docs currently but an exported function