### PR TITLE
Strip return statements from CPU kernels

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -137,7 +137,8 @@ function transform_cpu!(def, constargs, force_inbounds)
     push!(new_stmts, :(return nothing))
     def[:body] = Expr(:let,
         Expr(:block, let_constargs...),
-        Expr(:block, new_stmts...)
+        Expr(:block, new_stmts...),
+        :(return nothing)
     )
 end
 
@@ -231,6 +232,10 @@ function split(stmts,
                 push!(private, lhs)
                 continue
             end
+        elseif @capture(stmt, return x_)
+            # remove return statement from for loop
+            @assert x === nothing || x === :nothing
+            continue
         end
 
         push!(current, stmt)


### PR DESCRIPTION
fixes #461

@eschnett I remember know why I didn't add this in the first place.

```
@kernel function f(cond)
   if cond
       return
   end
   # do something useful
end
```

How should we compile this on the GPU?

The reason for the bug in #461 is that on the CPU the kernel

```
@kernel function set_matrix!(A)
   i,j = @index(Global, NTuple)
   A[i, j] = 1
   return nothing
end
```

Get's compiled as:

```
   for lane in ...
        i,j = @index(Global, NTuple)
        A[i, j] = 1
        return nothing
   end
```

And so we early terminate the execution.

It's easy enough for trailing return statements,
but for conditional returns it becomes as hard as conditional synchronize,
if not harder.

cc: @pxl-th

