### PR TITLE
Force Vararg specialization in CPU kernel launch

### DIFF
--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -34,7 +34,7 @@ function copyto!(backend::CPU, A, B)
     end
 end
 
-function (obj::Kernel{CPU})(args...; ndrange=nothing, workgroupsize=nothing, )
+function (obj::Kernel{CPU})(args::Vararg{Any, N}; ndrange=nothing, workgroupsize=nothing, ) where N
     ndrange, workgroupsize, iterspace, dynamic = launch_config(obj, ndrange, workgroupsize)
 
     if length(blocks(iterspace)) == 0


### PR DESCRIPTION
Julia de-specialized varargs 

https://docs.julialang.org/en/v1/manual/performance-tips/#Be-aware-of-when-Julia-avoids-specializing

