### PR TITLE
refactor: move StdLibs into extensions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,16 @@
 name = "KernelAbstractions"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
-version = "0.9.23"
+version = "0.9.24"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 Atomix = "a9b6321e-bd34-4604-b9c9-b65b8de01458"
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 UnsafeAtomics = "013be700-e6cd-48c3-b4a1-df204f14c38f"
@@ -36,9 +34,15 @@ julia = "1.6"
 
 [extensions]
 EnzymeExt = "EnzymeCore"
+LinearAlgebraExt = "LinearAlgebra"
+SparseArraysExt = "SparseArrays"
 
 [extras]
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/ext/LinearAlgebraExt.jl
+++ b/ext/LinearAlgebraExt.jl
@@ -1,0 +1,13 @@
+module LinearAlgebraExt
+
+using KernelAbstractions: KernelAbstractions
+if isdefined(Base, :get_extension)
+    using LinearAlgebra: Tridiagonal, Diagonal
+else
+    using ..LinearAlgebra: Tridiagonal, Diagonal
+end
+
+KernelAbstractions.get_backend(A::Diagonal) = KernelAbstractions.get_backend(A.diag)
+KernelAbstractions.get_backend(A::Tridiagonal) = KernelAbstractions.get_backend(A.d)
+
+end

--- a/ext/SparseArraysExt.jl
+++ b/ext/SparseArraysExt.jl
@@ -1,0 +1,14 @@
+module SparseArraysExt
+
+using KernelAbstractions: KernelAbstractions
+if isdefined(Base, :get_extension)
+    using SparseArrays: AbstractSparseArray, rowvals
+else
+    using ..SparseArrays: AbstractSparseArray, rowvals
+end
+
+function KernelAbstractions.get_backend(A::AbstractSparseArray)
+    return KernelAbstractions.get_backend(rowvals(A))
+end
+
+end

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -12,9 +12,7 @@ import PrecompileTools
 import Atomix: @atomic, @atomicswap, @atomicreplace
 import UnsafeAtomics
 
-using LinearAlgebra
 using MacroTools
-using SparseArrays
 using StaticArrays
 using Adapt
 
@@ -466,10 +464,6 @@ function get_backend end
 
 # Should cover SubArray, ReshapedArray, ReinterpretArray, Hermitian, AbstractTriangular, etc.:
 get_backend(A::AbstractArray) = get_backend(parent(A))
-
-get_backend(A::AbstractSparseArray) = get_backend(rowvals(A))
-get_backend(A::Diagonal) = get_backend(A.diag)
-get_backend(A::Tridiagonal) = get_backend(A.d)
 
 get_backend(::Array) = CPU()
 


### PR DESCRIPTION
```julia
julia> @time_imports using KernelAbstractions
     10.1 ms  UnsafeAtomics
      6.6 ms  Atomix
      0.7 ms  StaticArraysCore
    169.4 ms  StaticArrays
      0.4 ms  Adapt
      0.2 ms  AdaptStaticArraysExt
      1.9 ms  CEnum
      0.2 ms  LazyArtifacts
               ┌ 1.5 ms LLVMExtra_jll.__init__() 
    100.0 ms  LLVMExtra_jll 97.66% compilation time
               ┌ 0.2 ms LLVM.__init__() 
     30.7 ms  LLVM
      2.8 ms  UnsafeAtomicsLLVM
     12.1 ms  KernelAbstractions
      0.2 ms  StaticArrays → StaticArraysStatisticsExt
```

Moves both LinearAlgebra and SparseArrays into extensions. Saves around 250ms in load times (see #506)