### PR TITLE
Fix zeros erroring on an empty shape

### DIFF
--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -51,6 +51,7 @@ function default_cpu_workgroupsize(ndrange)
     # if the total kernel is small, don't launch multiple tasks
     n = prod(ndrange)
     if iszero(n)
+        # If the ndrange is zero return a workgroupsize of (1, 1,...)
         return map(one, ndrange)
     elseif n <= CPU_GRAINSIZE
         return ndrange

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -49,7 +49,10 @@ end
 const CPU_GRAINSIZE = 1024 # Vectorization, 4x unrolling, minimal grain size
 function default_cpu_workgroupsize(ndrange)
     # if the total kernel is small, don't launch multiple tasks
-    if prod(ndrange) <= CPU_GRAINSIZE
+    n = prod(ndrange)
+    if iszero(n)
+        return map(one, ndrange)
+    elseif n <= CPU_GRAINSIZE
         return ndrange
     else
         available = Ref(CPU_GRAINSIZE)

--- a/test/test.jl
+++ b/test/test.jl
@@ -296,4 +296,14 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         @test KernelAbstractions.default_cpu_workgroupsize((5, 7, 13, 17)) == (5, 7, 13, 2)
     end
 
+    @testset "empty arrays" begin
+        backend = Backend()
+        @test size(allocate(backend, Float32, 0)) == (0,)
+        @test size(allocate(backend, Float32, 3, 0)) == (3, 0)
+        @test size(allocate(backend, Float32, 0, 9)) == (0, 9)
+        @test size(KernelAbstractions.zeros(backend, Float32, 0)) == (0,)
+        @test size(KernelAbstractions.zeros(backend, Float32, 3, 0)) == (3, 0)
+        @test size(KernelAbstractions.zeros(backend, Float32, 0, 9)) == (0, 9)
+    end
+
 end


### PR DESCRIPTION
Fixes #504.

8b94cc693a970b3cd675f827c99b3311d06d0aec introduced this bug. I'm not sure of the best value to return in `default_cpu_workgroupsize` if `ndrange` is zero, but all ones seems to work. I might have not put the tests in the best place, too. Changes are welcome.