### PR TITLE
Remove test reliance on high-level features

### DIFF
--- a/test/copyto.jl
+++ b/test/copyto.jl
@@ -2,13 +2,13 @@ using KernelAbstractions, Test
 import KernelAbstractions: allocate, copyto!
 using Random
 
-function copyto_testsuite(Backend)
+function copyto_testsuite(Backend, ArrayT)
     M = 1024
     backend = Backend()
     ET = KernelAbstractions.supports_float64(backend) ? Float64 : Float32
 
-    A = rand!(allocate(backend, ET, M))
-    B = rand!(allocate(backend, ET, M))
+    A = ArrayT(rand(ET, M))
+    B = ArrayT(rand(ET, M))
 
     a = Array{ET}(undef, M)
     copyto!(backend, a, B)

--- a/test/localmem.jl
+++ b/test/localmem.jl
@@ -40,10 +40,11 @@ function localmem_testsuite(backend, ArrayT)
             A = ArrayT{Int}(undef, 64)
             kernel!(A, ndrange = size(A))
             synchronize(backend())
-            @test all(A[1:16] .== 16:-1:1)
-            @test all(A[17:32] .== 16:-1:1)
-            @test all(A[33:48] .== 16:-1:1)
-            @test all(A[49:64] .== 16:-1:1)
+            B = Array(A)
+            @test all(B[1:16] .== 16:-1:1)
+            @test all(B[17:32] .== 16:-1:1)
+            @test all(B[33:48] .== 16:-1:1)
+            @test all(B[49:64] .== 16:-1:1)
         end
     end
 end

--- a/test/private.jl
+++ b/test/private.jl
@@ -65,28 +65,29 @@ function private_testsuite(backend, ArrayT)
         A = ArrayT{Int}(undef, 64)
         private(backend(), 16)(A, ndrange = size(A))
         synchronize(backend())
-        @test all(A[1:16] .== 16:-1:1)
-        @test all(A[17:32] .== 16:-1:1)
-        @test all(A[33:48] .== 16:-1:1)
-        @test all(A[49:64] .== 16:-1:1)
+        B = Array(A)
+        @test all(B[1:16] .== 16:-1:1)
+        @test all(B[17:32] .== 16:-1:1)
+        @test all(B[33:48] .== 16:-1:1)
+        @test all(B[49:64] .== 16:-1:1)
 
         A = ArrayT{Int}(undef, 64, 64)
         A .= 1
         forloop(backend())(A, Val(size(A, 2)), ndrange = size(A, 1), workgroupsize = size(A, 1))
         synchronize(backend())
-        @test all(A[:, 1] .== 64)
-        @test all(A[:, 2:end] .== 1)
+        @test all(Array(A)[:, 1] .== 64)
+        @test all(Array(A)[:, 2:end] .== 1)
 
         B = ArrayT{Bool}(undef, size(A)...)
         typetest(backend(), 16)(A, B, ndrange = size(A))
         synchronize(backend())
-        @test all(B)
+        @test all(Array(B))
 
         A = ArrayT{Float32}(ones(64, 3));
         out = ArrayT{Float32}(undef, 64)
         reduce_private(backend(), 8)(out, A, ndrange = size(out))
         synchronize(backend())
-        @test all(out .== 3.0f0)
+        @test all(Array(out) .== 3.0f0)
     end
 
     if backend == CPU

--- a/test/private.jl
+++ b/test/private.jl
@@ -83,7 +83,7 @@ function private_testsuite(backend, ArrayT)
         synchronize(backend())
         @test all(Array(B))
 
-        A = ArrayT{Float32}(ones(64, 3));
+        A = ArrayT(ones(Float32, 64, 3))
         out = ArrayT{Float32}(undef, 64)
         reduce_private(backend(), 8)(out, A, ndrange = size(out))
         synchronize(backend())

--- a/test/test.jl
+++ b/test/test.jl
@@ -105,45 +105,45 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         A = allocate(backend, Int, 16, 16)
         index_linear_global(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A .== LinearIndices(A))
+        @test all(Array(A) .== LinearIndices(A))
 
         A = allocate(backend, Int, 8)
         index_linear_local(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A .== 1:8)
+        @test all(Array(A) .== 1:8)
 
         A = allocate(backend, Int, 16)
         index_linear_local(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A[1:8] .== 1:8)
-        @test all(A[9:16] .== 1:8)
+        @test all(Array(A)[1:8] .== 1:8)
+        @test all(Array(A)[9:16] .== 1:8)
 
         A = allocate(backend, Int, 8, 2)
         index_linear_local(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A[1:8] .== 1:8)
-        @test all(A[9:16] .== 1:8)
+        @test all(Array(A)[1:8] .== 1:8)
+        @test all(Array(A)[9:16] .== 1:8)
 
         A = allocate(backend, CartesianIndex{2}, 16, 16)
         index_cartesian_global(backend, 8)(A, ndrange = size(A))
         synchronize(backend)
-        @test all(A .== CartesianIndices(A))
+        @test all(Array(A) .== CartesianIndices(A))
 
         A = allocate(backend, CartesianIndex{1}, 16, 16)
         index_cartesian_global(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A[:] .== CartesianIndices((length(A),)))
+        @test all(Array(A)[:] .== CartesianIndices((length(A),)))
 
         # Non-multiplies of the workgroupsize
         A = allocate(backend, Int, 7, 7)
         index_linear_global(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A .== LinearIndices(A))
+        @test all(Array(A) .== LinearIndices(A))
 
         A = allocate(backend, Int, 5)
         index_linear_local(backend, 8)(A, ndrange = length(A))
         synchronize(backend)
-        @test all(A .== 1:5)
+        @test all(Array(A) .== 1:5)
     end
 
     @kernel function constarg(A, @Const(B))
@@ -199,7 +199,7 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
     A = KernelAbstractions.zeros(Backend(), Int64, 1024)
     kernel_val!(Backend())(A, Val(3), ndrange = size(A))
     synchronize(Backend())
-    @test all((a) -> a == 3, A)
+    @test all((a) -> a == 3, Array(A))
 
     @kernel function kernel_empty()
         nothing
@@ -276,7 +276,7 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
             A = KernelAbstractions.zeros(Backend(), Int64, 1024)
             context_kernel(Backend())(A, ndrange = size(A))
             synchronize(Backend())
-            @test all((a) -> a == 1, A)
+            @test all((a) -> a == 1, Array(A))
         else
             @test_throws ErrorException("This kernel is unavailable for backend CPU") context_kernel(Backend())
         end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -64,7 +64,7 @@ function testsuite(backend, backend_str, backend_mod, AT, DAT; skip_tests = Set{
     end
 
     @conditional_testset "copyto!" skip_tests begin
-        copyto_testsuite(backend)
+        copyto_testsuite(backend, AT)
     end
 
     @conditional_testset "Printing" skip_tests begin


### PR DESCRIPTION
This includes calls to `rand!`, `mapreducedim!`, type-mismatching constructors, etc. Even though most back-ends support these, KA.jl shouldn't assume so, making it easier to bootstrap a new platform.