### PR TITLE
Temporarily mark a test as broken on 1.11.

### DIFF
--- a/test/private.jl
+++ b/test/private.jl
@@ -97,7 +97,12 @@ function private_testsuite(backend, ArrayT)
                     optimize = true, ndrange = (64,),
                 )
             end
-            @test !occursin("gcframe", IR)
+            if VERSION >= v"1.11-" && Base.JLOptions().check_bounds > 0
+                # JuliaGPU/KernelAbstractions.jl#528
+                @test_broken !occursin("gcframe", IR)
+            else
+                @test !occursin("gcframe", IR)
+            end
         end
     end
 end


### PR DESCRIPTION
The idea is to get CI in a somewhat better state. Instead I've opened an issue: https://github.com/JuliaGPU/KernelAbstractions.jl/issues/528.