### PR TITLE
Remove unsupported Julia versions from Buildkite tests.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,12 +3,8 @@ steps:
     matrix:
       setup:
         version:
-          - "1.6"
-          - "1.7"
-          - "1.8"
-          - "1.9"
           - "1.10"
-          - "1.11-nightly"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -37,7 +33,7 @@ steps:
           - "1.8"
           - "1.9"
           - "1.10"
-          - "1.11-nightly"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -64,10 +60,8 @@ steps:
     matrix:
       setup:
         version:
-          - "1.8"
-          - "1.9"
           - "1.10"
-          - "1.11-nightly"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -94,10 +88,8 @@ steps:
     matrix:
       setup:
         version:
-          - "1.8"
-          - "1.9"
           - "1.10"
-          - "1.11-nightly"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"
@@ -123,37 +115,8 @@ steps:
     matrix:
       setup:
         version:
-          - "1.9"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "{{matrix.version}}"
-      - JuliaCI/julia-coverage#v1:
-          codecov: true
-    command: |
-      julia -e 'println("--- :julia: Instantiating project")
-                using Pkg
-                Pkg.develop(; path=pwd())
-                Pkg.develop(; name="AMDGPU")' || exit 3
-
-      julia -e 'println("+++ :julia: Running tests")
-                using Pkg
-                Pkg.test("AMDGPU"; coverage=true, test_args=["kernelabstractions"])'
-    agents:
-      queue: "juliagpu"
-      rocm: "*"
-      rocmgpu: "gfx1030"
-    timeout_in_minutes: 120
-    soft_fail:
-      - exit_status: 3
-    env:
-      JULIA_NUM_THREADS: 4
-
-  - label: "AMDGPU Julia {{matrix.version}}"
-    matrix:
-      setup:
-        version:
           - "1.10"
-          - "1.11-nightly"
+          - "1.11"
     plugins:
       - JuliaCI/julia#v1:
           version: "{{matrix.version}}"


### PR DESCRIPTION
CUDA.jl, Metal.jl, oneAPI.jl and AMDGPU.jl are all being `develop`ed here, however, the current master branches of said packages only support Julia 1.10+, leading to all these tests failing all the time. Remove the older Julia versions from the roster, except for the Enzyme job where CUDA is `add`ed.