### PR TITLE
Add Atomix v1 compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ UnsafeAtomicsLLVM = "d80eeb9a-aca5-4d75-85e5-170c8b632249"
 
 [compat]
 Adapt = "0.4, 1.0, 2.0, 3.0, 4"
-Atomix = "0.1"
+Atomix = "0.1, 1"
 EnzymeCore = "0.7, 0.8.1"
 InteractiveUtils = "1.6"
 LinearAlgebra = "1.6"


### PR DESCRIPTION
Not actually breaking since the only changes are the gpu backends from subpackages to extensions and it doesn't seem like AtomixCUDA was ever actually released.

Atomix v1 should be released once https://github.com/JuliaConcurrent/Atomix.jl/pull/43 is merged. (Edit: done)