### PR TITLE
KernelIntrinsics

### DIFF
--- a/src/intrinsics.jl
+++ b/src/intrinsics.jl
@@ -1,0 +1,52 @@
+module KernelIntrinsics
+
+"""
+    get_global_size()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Return the number of global work-items specified.
+
+!!! note
+    1-based.
+"""
+function get_global_size end
+
+"""
+    get_global_id()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Returns the unique global work-item ID.
+"""
+function get_global_id end
+
+"""
+    get_local_size()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Return the number of local work-items specified.
+"""
+function get_local_size end
+
+"""
+    get_local_id()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Returns the unique local work-item ID.
+"""
+function get_local_id end
+
+"""
+    get_num_groups()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Returns the number of groups.
+"""
+function get_num_groups end
+
+"""
+    get_group_id()::@NamedTuple{x::Int32, y::Int32, z::Int32}
+
+Returns the unique group ID.
+"""
+function get_group_id end
+
+function localmemory end
+function barrier end
+function print end
+
+end

--- a/src/pocl/backend.jl
+++ b/src/pocl/backend.jl
@@ -139,29 +139,18 @@ end
 
 
 ## Indexing Functions
+const KI = KA.KernelIntrinsics
 
-@device_override @inline function KA.__index_Local_Linear(ctx)
-    return get_local_id(1)
+@device_override @inline function KI.get_local_id()
+    return (; x = get_local_id(1), y = get_local_id(2), z = get_local_id(3))
 end
 
-@device_override @inline function KA.__index_Group_Linear(ctx)
-    return get_group_id(1)
+@device_override @inline function KI.get_group_id()
+    return (; x = get_group_id(1), y = get_group_id(2), z = get_group_id(3))
 end
 
-@device_override @inline function KA.__index_Global_Linear(ctx)
-    return get_global_id(1)
-end
-
-@device_override @inline function KA.__index_Local_Cartesian(ctx)
-    @inbounds KA.workitems(KA.__iterspace(ctx))[get_local_id(1)]
-end
-
-@device_override @inline function KA.__index_Group_Cartesian(ctx)
-    @inbounds KA.blocks(KA.__iterspace(ctx))[get_group_id(1)]
-end
-
-@device_override @inline function KA.__index_Global_Cartesian(ctx)
-    return @inbounds KA.expand(KA.__iterspace(ctx), get_group_id(1), get_local_id(1))
+@device_override @inline function KI.get_global_id()
+    return (; x = get_global_id(1), y = get_global_id(2), z = get_global_id(3))
 end
 
 @device_override @inline function KA.__validindex(ctx)


### PR DESCRIPTION
The goal is to allow for kernels to be written without relying on KernelAbstractions macros

cc: @maleadt @pxl-th
