### PR TITLE
Extend `supports_atomics` to include type

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -553,15 +553,15 @@ function ones(backend::Backend, ::Type{T}, dims::Tuple) where {T}
 end
 
 """
-    supports_atomics(::Backend)::Bool
+    supports_atomics(::Backend, [T::Type{<:Number}])::Bool
 
-Returns whether `@atomic` operations are supported by the backend.
+Returns whether `@atomic` operations of type `T` are supported by the backend.
 
 !!! note
     Backend implementations **must** implement this function,
     only if they **do not** support atomic operations with Atomix.
 """
-supports_atomics(::Backend) = true
+supports_atomics(::Backend, T::Type{<:Number}=Number) = true
 
 """
     supports_float64(::Backend)::Bool

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,6 +24,9 @@ struct NewBackend <: KernelAbstractions.GPU end
     @test_throws MethodError KernelAbstractions.ones(backend, Float32, 1)
 
     @test KernelAbstractions.supports_atomics(backend) == true
+    @test KernelAbstractions.supports_atomics(backend, Float64) == true
+    @test KernelAbstractions.supports_atomics(backend, Int32) == true
+
     @test KernelAbstractions.supports_float64(backend) == true
 
     @test KernelAbstractions.priority!(backend, :high) === nothing


### PR DESCRIPTION
See #594