### PR TITLE
prevent `get_backend` from overflowing the stack

### DIFF
--- a/ext/LinearAlgebraExt.jl
+++ b/ext/LinearAlgebraExt.jl
@@ -3,7 +3,7 @@ module LinearAlgebraExt
 using KernelAbstractions: KernelAbstractions
 using LinearAlgebra: Tridiagonal, Diagonal
 
-KernelAbstractions.get_backend(A::Diagonal) = KernelAbstractions.get_backend(A.diag)
-KernelAbstractions.get_backend(A::Tridiagonal) = KernelAbstractions.get_backend(A.d)
+KernelAbstractions.get_backend(A::Diagonal) = KernelAbstractions.get_backend_recur(x -> x.diag, A)
+KernelAbstractions.get_backend(A::Tridiagonal) = KernelAbstractions.get_backend_recur(x -> x.d, A)
 
 end

--- a/ext/LinearAlgebraExt.jl
+++ b/ext/LinearAlgebraExt.jl
@@ -3,7 +3,7 @@ module LinearAlgebraExt
 using KernelAbstractions: KernelAbstractions
 using LinearAlgebra: Tridiagonal, Diagonal
 
-KernelAbstractions.get_backend(A::Diagonal) = KernelAbstractions.get_backend_recur(x -> x.diag, A)
-KernelAbstractions.get_backend(A::Tridiagonal) = KernelAbstractions.get_backend_recur(x -> x.d, A)
+KernelAbstractions.get_backend(A::Diagonal) = KernelAbstractions.get_backend(A.diag)
+KernelAbstractions.get_backend(A::Tridiagonal) = KernelAbstractions.get_backend(A.d)
 
 end

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -510,15 +510,6 @@ Get a [`Backend`](@ref) instance suitable for array `A`.
 """
 function get_backend end
 
-function get_backend_recur(f::F, x) where {F}
-    t() = throw(ArgumentError("throwing to prevent a stack overflow, possibly a `get_backend` method is missing?"))
-    y = f(x)
-    if y isa typeof(x)
-        @noinline t()
-    end
-    return get_backend(y)
-end
-
 # Should cover SubArray, ReshapedArray, ReinterpretArray, Hermitian, AbstractTriangular, etc.:
 function get_backend(A::AbstractArray)
     P = parent(A)

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -510,8 +510,17 @@ Get a [`Backend`](@ref) instance suitable for array `A`.
 """
 function get_backend end
 
+function get_backend_recur(f::F, x) where {F}
+    t() = throw(ArgumentError("throwing to prevent a stack overflow, possibly a `get_backend` method is missing?"))
+    y = f(x)
+    if y isa typeof(x)
+        @noinline t()
+    end
+    return get_backend(y)
+end
+
 # Should cover SubArray, ReshapedArray, ReinterpretArray, Hermitian, AbstractTriangular, etc.:
-get_backend(A::AbstractArray) = get_backend(parent(A))
+get_backend(A::AbstractArray) = get_backend_recur(parent, A)
 
 # Define:
 #   adapt_storage(::Backend, a::Array) = adapt(BackendArray, a)

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -520,7 +520,13 @@ function get_backend_recur(f::F, x) where {F}
 end
 
 # Should cover SubArray, ReshapedArray, ReinterpretArray, Hermitian, AbstractTriangular, etc.:
-get_backend(A::AbstractArray) = get_backend_recur(parent, A)
+function get_backend(A::AbstractArray)
+    P = parent(A)
+    if P isa typeof(A)
+        throw(ArgumentError("Implement `KernelAbstractions.get_backend(::$(typeof(A)))`"))
+    end
+    return get_backend(P)
+end
 
 # Define:
 #   adapt_storage(::Backend, a::Array) = adapt(BackendArray, a)

--- a/test/test.jl
+++ b/test/test.jl
@@ -7,6 +7,9 @@ using Adapt
 
 identity(x) = x
 
+struct UnknownAbstractVector <: AbstractVector{Float32}  # issue #588
+end
+
 function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; skip_tests = Set{String}())
     @conditional_testset "partition" skip_tests begin
         backend = Backend()
@@ -80,6 +83,7 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         @test @inferred(KernelAbstractions.get_backend(view(A, 2:4, 1:3))) isa backendT
         @test @inferred(KernelAbstractions.get_backend(Diagonal(x))) isa backendT
         @test @inferred(KernelAbstractions.get_backend(Tridiagonal(A))) isa backendT
+        @test_throws ArgumentError KernelAbstractions.get_backend(UnknownAbstractVector())  # issue #588
     end
 
     @conditional_testset "sparse" skip_tests begin


### PR DESCRIPTION
Prevent the `get_backend` methods from overflowing the stack/recurring without bound.

Hoping this doesn't cause inference issues due to deeper call stacks.

Fixes #588