### PR TITLE
Disable Float16 on the CPU backend

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,13 +9,16 @@ using Random
 
 if !haskey(ENV, "KA_BACKEND")
     const BACKEND = CPU()
+    const Ts = (Float32, Float64)
 else
     backend = ENV["KA_BACKEND"]
     if backend == "CPU"
         const BACKEND = CPU()
+        const Ts = (Float32, Float64)
     elseif backend == "CUDA"
         using CUDA
         const BACKEND = CUDABackend()
+        const Ts = (Float16, Float32, Float64)
     else
         error("Backend $backend not recognized")
     end
@@ -31,7 +34,7 @@ end
 SUITE["saxpy"] = BenchmarkGroup()
 
 let static = BenchmarkGroup()
-    for T in (Float16, Float32, Float64)
+    for T in Ts
         dtype = BenchmarkGroup()
         for N in (64, 256, 512, 1024, 2048, 4096, 16384, 32768, 65536, 262144, 1048576)
             dtype[N] = @benchmarkable begin
@@ -49,7 +52,7 @@ let static = BenchmarkGroup()
 end
 
 let default = BenchmarkGroup()
-    for T in (Float16, Float32, Float64)
+    for T in Ts
         dtype = BenchmarkGroup()
         for N in (64, 256, 512, 1024, 2048, 4096, 16384, 32768, 65536, 262144, 1048576)
             dtype[N] = @benchmarkable begin

--- a/src/pocl/compiler/compilation.jl
+++ b/src/pocl/compiler/compilation.jl
@@ -48,6 +48,13 @@ end
     supports_fp16 = "cl_khr_fp16" in dev.extensions
     supports_fp64 = "cl_khr_fp64" in dev.extensions
 
+    if !supports_fp64
+        @warn_once "Device does not support double precision floating point operations" dev
+    end
+    if !supports_fp16
+        @warn_once "Device does not support half precision floating point operations" dev
+    end
+
     # create GPUCompiler objects
     target = SPIRVCompilerTarget(; supports_fp16, supports_fp64, version = v"1.2", kwargs...)
     params = OpenCLCompilerParams()

--- a/src/pocl/compiler/compilation.jl
+++ b/src/pocl/compiler/compilation.jl
@@ -48,12 +48,6 @@ end
     supports_fp16 = "cl_khr_fp16" in dev.extensions
     supports_fp64 = "cl_khr_fp64" in dev.extensions
 
-    if !supports_fp64
-        @warn_once "Device does not support double precision floating point operations" dev
-    end
-    if !supports_fp16
-        @warn_once "Device does not support half precision floating point operations" dev
-    end
 
     # create GPUCompiler objects
     target = SPIRVCompilerTarget(; supports_fp16, supports_fp64, version = v"1.2", kwargs...)


### PR DESCRIPTION
Currently fails with:

```
RROR: LoadError: InvalidIRError: compiling MethodInstance for KernelAbstractions.gpu_init_kernel(::KernelAbstractions.CompilerMetadata{KernelAbstractions.NDIteration.DynamicSize, KernelAbstractions.NDIteration.DynamicCheck, Nothing, CartesianIndices{1, Tuple{Base.OneTo{Int64}}}, KernelAbstractions.NDIteration.NDRange{1, KernelAbstractions.NDIteration.DynamicSize, KernelAbstractions.NDIteration.DynamicSize, CartesianIndices{1, Tuple{Base.OneTo{Int64}}}, CartesianIndices{1, Tuple{Base.OneTo{Int64}}}}}, ::KernelAbstractions.POCL.CLDeviceVector{Float16, 1}, ::typeof(zero), ::Type{Float16}) resulted in invalid LLVM IR
Reason: unsupported use of half value
Stacktrace:
  [1] macro expansion
    @ ~/.julia/packages/LLVM/2JPxT/src/interop/base.jl:39
  [2] macro expansion
    @ ./none:0
  [3] pointerset
    @ ./none:0
  [4] unsafe_store!
    @ ~/.julia/packages/LLVM/2JPxT/src/interop/pointer.jl:88
  [5] arrayset_bits
    @ ~/.julia/packages/KernelAbstractions/JUTlQ/src/pocl/device/array.jl:139
  [6] #arrayset
    @ ~/.julia/packages/KernelAbstractions/JUTlQ/src/pocl/device/array.jl:130
  [7] setindex!
    @ ~/.julia/packages/KernelAbstractions/JUTlQ/src/pocl/device/array.jl:171
  [8] macro expansion
    @ ~/.julia/packages/KernelAbstractions/JUTlQ/src/KernelAbstractions.jl:819
  [9] gpu_init_kernel
    @ ~/.julia/packages/KernelAbstractions/JUTlQ/src/macros.jl:185
 [10] gpu_init_kernel
    @ ./none:0
```

cc: @maleadt
