### PR TITLE
avoid boxing when `@kernel` is used as a closure

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -349,5 +349,20 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         end
     end
 
+    @testset "`@kernel` as a closure" begin
+        function foo()
+            @kernel function kernel(A)
+                i = @index(Global)
+                A[i] = 1
+            end
+            return kernel
+        end
+        ftypes = fieldtypes(typeof(foo()))
+        @test !any(T -> T <: Core.Box, ftypes)
+        @test all(ftypes) do T
+            !any(T -> T <: Core.Box, fieldtypes(T))
+        end
+    end
+
     return
 end


### PR DESCRIPTION
This allows uses of `@kernel` inside of functions without running into
JuliaLang/julia#53295. One thing I have been wondering though: Is the
`@isdefined` check here really necessary? In global scope it should just
override the previous definition and for closures these kind of if
statements are ignored anyways.
