### PR TITLE
[main] avoid boxing when `@kernel` is used as a closure

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -34,14 +34,16 @@ function __kernel(expr, force_inbounds = false, unsafe_indices = false)
     gpu_function = combinedef(def_gpu)
 
     # create constructor functions
+    _name = Symbol(:_, name)
     constructors = quote
         if $(name isa Symbol ? :(!@isdefined($name)) : true)
-            Core.@__doc__ $name(dev) = $name(dev, $DynamicSize(), $DynamicSize())
-            $name(dev, size) = $name(dev, $StaticSize(size), $DynamicSize())
-            $name(dev, size, range) = $name(dev, $StaticSize(size), $StaticSize(range))
-            function $name(dev::Dev, sz::S, range::NDRange) where {Dev, S <: $_Size, NDRange <: $_Size}
+            function $_name(dev::Dev, sz::S, range::NDRange) where {Dev, S <: $_Size, NDRange <: $_Size}
                 return $construct(dev, sz, range, $gpu_name)
             end
+            Core.@__doc__ $name(dev) = $_name(dev, $DynamicSize(), $DynamicSize())
+            $name(dev, size) = $_name(dev, $StaticSize(size), $DynamicSize())
+            $name(dev, size, range) = $_name(dev, $StaticSize(size), $StaticSize(range))
+            $name(dev, size::$_Size, range::$_Size) = $_name(dev, size, range)
         end
     end
 

--- a/test/test.jl
+++ b/test/test.jl
@@ -307,5 +307,20 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         @test all(a -> a == 0, @view(Ah[(length(A) ÷ 2 + 1):end]))
     end
 
+    @testset "`@kernel` as a closure" begin
+        function foo()
+            @kernel function kernel(A)
+                i = @index(Global)
+                A[i] = 1
+            end
+            return kernel
+        end
+        ftypes = fieldtypes(typeof(foo()))
+        @test !any(T -> T <: Core.Box, ftypes)
+        @test all(ftypes) do T
+            !any(T -> T <: Core.Box, fieldtypes(T))
+        end
+    end
+
     return
 end


### PR DESCRIPTION
This allows uses of `@kernel` inside of functions without running into
JuliaLang/julia#53295.
