### PR TITLE
Proof-of-concept unified memory allocations

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -564,7 +564,7 @@ end
 Returns whether `@atomic` operations are supported by the backend.
 
 !!! note
-    Backend implementations **must** implement this function,
+    Backend implementations **must** implement this function
     only if they **do not** support atomic operations with Atomix.
 """
 supports_atomics(::Backend) = true
@@ -575,7 +575,7 @@ supports_atomics(::Backend) = true
 Returns whether `Float64` values are supported by the backend.
 
 !!! note
-    Backend implementations **must** implement this function,
+    Backend implementations **must** implement this function
     only if they **do not** support `Float64`.
 """
 supports_float64(::Backend) = true

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -524,39 +524,54 @@ end
 #   adapt_storage(::Backend, a::BackendArray) = a
 
 """
-    allocate(::Backend, Type, dims...)::AbstractArray
+    allocate(::Backend, Type, dims...; unified=false)::AbstractArray
 
-Allocate a storage array appropriate for the computational backend.
+Allocate a storage array appropriate for the computational backend. `unified`
+allocates an array using unified memory if the backend supports it. Use
+[`supports_unified`](@ref) to determine whether it is supported by a backend.
 
 !!! note
     Backend implementations **must** implement `allocate(::NewBackend, T, dims::Tuple)`
 """
-allocate(backend::Backend, T::Type, dims...) = allocate(backend, T, dims)
-allocate(backend::Backend, T::Type, dims::Tuple) = throw(MethodError(allocate, (backend, T, dims)))
+allocate(backend::Backend, T::Type, dims...; unified=false) = allocate(backend, T, dims; unified)
+allocate(backend::Backend, T::Type, dims::Tuple; unified=false) = throw(MethodError(allocate, (backend, T, dims)))
 
 """
-    zeros(::Backend, Type, dims...)::AbstractArray
+    zeros(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with zeros.
+`unified` allocates an array using unified memory if the backend supports it.
 """
-zeros(backend::Backend, T::Type, dims...) = zeros(backend, T, dims)
-function zeros(backend::Backend, ::Type{T}, dims::Tuple) where {T}
-    data = allocate(backend, T, dims...)
+zeros(backend::Backend, T::Type, dims...; kwargs...) = zeros(backend, T, dims; kwargs...)
+function zeros(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+    data = allocate(backend, T, dims...; unified)
     fill!(data, zero(T))
     return data
 end
 
 """
-    ones(::Backend, Type, dims...)::AbstractArray
+    ones(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with ones.
+`unified` allocates an array using unified memory if the backend supports it.
 """
-ones(backend::Backend, T::Type, dims...) = ones(backend, T, dims)
-function ones(backend::Backend, ::Type{T}, dims::Tuple) where {T}
-    data = allocate(backend, T, dims)
+ones(backend::Backend, T::Type, dims...; kwargs...) = ones(backend, T, dims; kwargs...)
+function ones(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+    data = allocate(backend, T, dims; unified)
     fill!(data, one(T))
     return data
 end
+
+"""
+    supports_unified(::Backend)::Bool
+
+Returns whether unified memory arrays are supported by the backend.
+
+!!! note
+    Backend implementations **must** implement this function
+    only if they **do not** support unified memory.
+"""
+supports_unified(::Backend) = true
 
 """
     supports_atomics(::Backend)::Bool

--- a/test/test.jl
+++ b/test/test.jl
@@ -77,6 +77,15 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         backendT = typeof(backend).name.wrapper # To look through CUDABackend{true, false}
         @test backend isa backendT
 
+        unified = supports_unified(backend)
+        @test unified isa Bool
+        U = allocate(backend, Float32, 5; unified)
+        if unified
+            @test U[3] isa Float32
+        else
+            @test_throws U[3]
+        end
+
         x = allocate(backend, Float32, 5)
         A = allocate(backend, Float32, 5, 5)
         @test @inferred(KernelAbstractions.get_backend(A)) isa backendT


### PR DESCRIPTION
Close #601 

@vchuravy The idea is that you request unified if you want to uallocate some memory with unified memory to speed up operations that necessitate CPU access (like 1d reduce result). Otherwise just use the default storage type. Backends would have to add support for the `unified` kwarg.