### PR TITLE
[0.9] Unified memory allocations

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -21,6 +21,7 @@ allocate
 
 ```@docs
 KernelAbstractions.zeros
+KernelAbstractions.supports_unified
 ```
 
 ## Internal

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -587,8 +587,7 @@ Returns whether unified memory arrays are supported by the backend.
 
 !!! note
     Backend implementations **should** implement this function
-    only if they **do** support unified memory. It will be required
-    in KernelAbstractions 0.10.
+    only if they **do** support unified memory.
 """
 supports_unified(::Backend) = false
 

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -534,9 +534,9 @@ Adapt.adapt_storage(::CPU, a::Array) = a
 """
     allocate(::Backend, Type, dims...; unified=false)::AbstractArray
 
-Allocate a storage array appropriate for the computational backend. `unified`
-allocates an array using unified memory if the backend supports it. Use
-[`supports_unified`](@ref) to determine whether it is supported by a backend.
+Allocate a storage array appropriate for the computational backend. `unified=true`
+allocates an array using unified memory if the backend supports it and throws otherwise.
+Use [`supports_unified`](@ref) to determine whether it is supported by a backend.
 
 !!! note
     Backend implementations **must** implement `allocate(::NewBackend, T, dims::Tuple)`
@@ -558,7 +558,8 @@ end
     zeros(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with zeros.
-`unified` allocates an array using unified memory if the backend supports it.
+`unified=true` allocates an array using unified memory if the backend supports it and
+throws otherwise.
 """
 zeros(backend::Backend, T::Type, dims...; kwargs...) = zeros(backend, T, dims; kwargs...)
 function zeros(backend::Backend, ::Type{T}, dims::Tuple; kwargs...) where {T}
@@ -571,7 +572,8 @@ end
     ones(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with ones.
-`unified` allocates an array using unified memory if the backend supports it.
+`unified=true` allocates an array using unified memory if the backend supports it and
+throws otherwise.
 """
 ones(backend::Backend, T::Type, dims...; kwargs...) = ones(backend, T, dims; kwargs...)
 function ones(backend::Backend, ::Type{T}, dims::Tuple; kwargs...) where {T}

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -541,8 +541,8 @@ allocates an array using unified memory if the backend supports it. Use
 !!! note
     Backend implementations **must** implement `allocate(::NewBackend, T, dims::Tuple)`
 """
-allocate(backend::Backend, T::Type, dims...; unified=false) = allocate(backend, T, dims; unified)
-allocate(backend::Backend, T::Type, dims::Tuple; unified=false) = throw(MethodError(allocate, (backend, T, dims)))
+allocate(backend::Backend, T::Type, dims...; unified = false) = allocate(backend, T, dims; unified)
+allocate(backend::Backend, T::Type, dims::Tuple; unified = false) = throw(MethodError(allocate, (backend, T, dims)))
 
 """
     zeros(::Backend, Type, dims...; unified=false)::AbstractArray
@@ -551,7 +551,7 @@ Allocate a storage array appropriate for the computational backend filled with z
 `unified` allocates an array using unified memory if the backend supports it.
 """
 zeros(backend::Backend, T::Type, dims...; kwargs...) = zeros(backend, T, dims; kwargs...)
-function zeros(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+function zeros(backend::Backend, ::Type{T}, dims::Tuple; unified = false) where {T}
     data = allocate(backend, T, dims...; unified)
     fill!(data, zero(T))
     return data
@@ -564,7 +564,7 @@ Allocate a storage array appropriate for the computational backend filled with o
 `unified` allocates an array using unified memory if the backend supports it.
 """
 ones(backend::Backend, T::Type, dims...; kwargs...) = ones(backend, T, dims; kwargs...)
-function ones(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+function ones(backend::Backend, ::Type{T}, dims::Tuple; unified = false) where {T}
     data = allocate(backend, T, dims; unified)
     fill!(data, one(T))
     return data

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -532,39 +532,54 @@ get_backend(::Array) = CPU()
 Adapt.adapt_storage(::CPU, a::Array) = a
 
 """
-    allocate(::Backend, Type, dims...)::AbstractArray
+    allocate(::Backend, Type, dims...; unified=false)::AbstractArray
 
-Allocate a storage array appropriate for the computational backend.
+Allocate a storage array appropriate for the computational backend. `unified`
+allocates an array using unified memory if the backend supports it. Use
+[`supports_unified`](@ref) to determine whether it is supported by a backend.
 
 !!! note
     Backend implementations **must** implement `allocate(::NewBackend, T, dims::Tuple)`
 """
-allocate(backend::Backend, T::Type, dims...) = allocate(backend, T, dims)
-allocate(backend::Backend, T::Type, dims::Tuple) = throw(MethodError(allocate, (backend, T, dims)))
+allocate(backend::Backend, T::Type, dims...; unified=false) = allocate(backend, T, dims; unified)
+allocate(backend::Backend, T::Type, dims::Tuple; unified=false) = throw(MethodError(allocate, (backend, T, dims)))
 
 """
-    zeros(::Backend, Type, dims...)::AbstractArray
+    zeros(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with zeros.
+`unified` allocates an array using unified memory if the backend supports it.
 """
-zeros(backend::Backend, T::Type, dims...) = zeros(backend, T, dims)
-function zeros(backend::Backend, ::Type{T}, dims::Tuple) where {T}
-    data = allocate(backend, T, dims...)
+zeros(backend::Backend, T::Type, dims...; kwargs...) = zeros(backend, T, dims; kwargs...)
+function zeros(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+    data = allocate(backend, T, dims...; unified)
     fill!(data, zero(T))
     return data
 end
 
 """
-    ones(::Backend, Type, dims...)::AbstractArray
+    ones(::Backend, Type, dims...; unified=false)::AbstractArray
 
 Allocate a storage array appropriate for the computational backend filled with ones.
+`unified` allocates an array using unified memory if the backend supports it.
 """
-ones(backend::Backend, T::Type, dims...) = ones(backend, T, dims)
-function ones(backend::Backend, ::Type{T}, dims::Tuple) where {T}
-    data = allocate(backend, T, dims)
+ones(backend::Backend, T::Type, dims...; kwargs...) = ones(backend, T, dims; kwargs...)
+function ones(backend::Backend, ::Type{T}, dims::Tuple; unified=false) where {T}
+    data = allocate(backend, T, dims; unified)
     fill!(data, one(T))
     return data
 end
+
+"""
+    supports_unified(::Backend)::Bool
+
+Returns whether unified memory arrays are supported by the backend.
+
+!!! note
+    Backend implementations **must** implement this function
+    only if they **do not** support unified memory.
+"""
+supports_unified(::Backend) = true
 
 """
     supports_atomics(::Backend)::Bool

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -540,13 +540,14 @@ allocates an array using unified memory if the backend supports it. Use
 
 !!! note
     Backend implementations **must** implement `allocate(::NewBackend, T, dims::Tuple)`
+    Backend implementations **should** implement `allocate(::NewBackend, T, dims::Tuple; unified::Bool=false)`
 """
 allocate(backend::Backend, T::Type, dims...; kwargs...) = allocate(backend, T, dims; kwargs...)
 function allocate(backend::Backend, T::Type, dims::Tuple; unified::Union{Nothing, Bool} = nothing)
     if isnothing(unified)
         throw(MethodError(allocate, (backend, T, dims)))
     elseif unified
-        throw(ArgumentError("`$(typeof(backend))` either does not support unified memory or it has not yet defined `allocate(backend::$backend, T::Type, dims::Tuple; unified::Bool)`"))
+        throw(ArgumentError("`$(typeof(backend))` does not support unified memory. If you believe it does, please open a github issue."))
     else
         return allocate(backend, T, dims)
     end

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -543,12 +543,12 @@ allocates an array using unified memory if the backend supports it. Use
 """
 allocate(backend::Backend, T::Type, dims...; kwargs...) = allocate(backend, T, dims; kwargs...)
 function allocate(backend::Backend, T::Type, dims::Tuple; unified::Union{Nothing, Bool} = nothing)
-    return if isnothing(unified)
+    if isnothing(unified)
         throw(MethodError(allocate, (backend, T, dims)))
     elseif unified
         throw(ArgumentError("`$(typeof(backend))` either does not support unified memory or it has not yet defined `allocate(backend::$backend, T::Type, dims::Tuple; unified::Bool)`"))
     else
-        allocate(backend, T, dims)
+        return allocate(backend, T, dims)
     end
 end
 

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -543,7 +543,7 @@ allocates an array using unified memory if the backend supports it. Use
 """
 allocate(backend::Backend, T::Type, dims...; kwargs...) = allocate(backend, T, dims; kwargs...)
 function allocate(backend::Backend, T::Type, dims::Tuple; unified::Union{Nothing, Bool} = nothing)
-    if isnothing(unified)
+    return if isnothing(unified)
         throw(MethodError(allocate, (backend, T, dims)))
     elseif unified
         throw(ArgumentError("`$(typeof(backend))` either does not support unified memory or it has not yet defined `allocate(backend::$backend, T::Type, dims::Tuple; unified::Bool)`"))

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -586,8 +586,9 @@ end
 Returns whether unified memory arrays are supported by the backend.
 
 !!! note
-    Backend implementations **must** implement this function
-    only if they **do** support unified memory.
+    Backend implementations **should** implement this function
+    only if they **do** support unified memory. It will be required
+    in KernelAbstractions 0.10.
 """
 supports_unified(::Backend) = false
 

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -1,16 +1,16 @@
 unsafe_free!(::AbstractArray) = return
 synchronize(::CPU) = nothing
 
-allocate(::CPU, ::Type{T}, dims::Tuple) where {T} = Array{T}(undef, dims)
+allocate(::CPU, ::Type{T}, dims::Tuple; unified::Bool=false) where {T} = Array{T}(undef, dims)
 
-function zeros(backend::CPU, ::Type{T}, dims::Tuple) where {T}
-    arr = allocate(backend, T, dims)
+function zeros(backend::CPU, ::Type{T}, dims::Tuple; kwargs...) where {T}
+    arr = allocate(backend, T, dims; kwargs...)
     kernel = init_kernel(backend)
     kernel(arr, zero, T, ndrange = length(arr))
     return arr
 end
-function ones(backend::CPU, ::Type{T}, dims::Tuple) where {T}
-    arr = allocate(backend, T, dims)
+function ones(backend::CPU, ::Type{T}, dims::Tuple; kwargs...) where {T}
+    arr = allocate(backend, T, dims; kwargs...)
     kernel = init_kernel(backend)
     kernel(arr, one, T; ndrange = length(arr))
     return arr
@@ -34,6 +34,7 @@ end
 
 functional(::CPU) = true
 pagelock!(::CPU, x) = nothing
+supports_unified(::CPU) = true
 
 function (obj::Kernel{CPU})(args...; ndrange = nothing, workgroupsize = nothing)
     ndrange, workgroupsize, iterspace, dynamic = launch_config(obj, ndrange, workgroupsize)

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -1,7 +1,7 @@
 unsafe_free!(::AbstractArray) = return
 synchronize(::CPU) = nothing
 
-allocate(::CPU, ::Type{T}, dims::Tuple; unified::Bool=false) where {T} = Array{T}(undef, dims)
+allocate(::CPU, ::Type{T}, dims::Tuple; unified::Bool = false) where {T} = Array{T}(undef, dims)
 
 function zeros(backend::CPU, ::Type{T}, dims::Tuple; kwargs...) where {T}
     arr = allocate(backend, T, dims; kwargs...)

--- a/test/test.jl
+++ b/test/test.jl
@@ -78,7 +78,7 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         backendT = typeof(backend).name.wrapper # To look through CUDABackend{true, false}
         @test backend isa backendT
 
-        unified = supports_unified(backend)
+        unified = KernelAbstractions.supports_unified(backend)
         @test unified isa Bool
         U = allocate(backend, Float32, 5; unified)
         if unified

--- a/test/test.jl
+++ b/test/test.jl
@@ -84,7 +84,7 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         if unified
             @test U[3] isa Float32
         else
-            @test_throws U[3]
+            @test_throws ErrorException U[3]
         end
 
         x = allocate(backend, Float32, 5)

--- a/test/test.jl
+++ b/test/test.jl
@@ -78,6 +78,15 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         backendT = typeof(backend).name.wrapper # To look through CUDABackend{true, false}
         @test backend isa backendT
 
+        unified = supports_unified(backend)
+        @test unified isa Bool
+        U = allocate(backend, Float32, 5; unified)
+        if unified
+            @test U[3] isa Float32
+        else
+            @test_throws U[3]
+        end
+
         x = allocate(backend, Float32, 5)
         A = allocate(backend, Float32, 5, 5)
         @test @inferred(KernelAbstractions.get_backend(A)) isa backendT

--- a/test/test.jl
+++ b/test/test.jl
@@ -83,8 +83,6 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         U = allocate(backend, Float32, 5; unified)
         if unified
             @test U[3] isa Float32
-        else
-            @test_throws ErrorException U[3]
         end
 
         x = allocate(backend, Float32, 5)


### PR DESCRIPTION
See #630 

Feedback from #630 has been addressed. When not implemented in the backend, no kwarg or `unified=false` just work, while `unified=true` will fail unless implemented.