### PR TITLE
Use `macos-15-intel`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.10', '1.11']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-13, macOS-15, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2025]
         arch: [x64, arm64]
         pocl: [jll, local]
         exclude:
@@ -35,14 +35,14 @@ jobs:
           # macOS 13 is Intel-only, while macOS 14+ only support Apple Silicon
           - os: macOS-15
             arch: x64
-          - os: macOS-13
+          - os: macOS-15-intel
             arch: arm64
-          - os: macOS-13
+          - os: macOS-15-intel
             pocl: local
           - os: macOS-15
             pocl: local
           - os: windows-2025
-            pocl: local    
+            pocl: local
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/install-juliaup@v2


### PR DESCRIPTION
macos 13 images are going away soon so replace the Intel runners with `macos-15-intel` runners.

I cancelled the buildkite tests since this doesn't affect them until we rebase once the other PRs that'll get CI passing are merged.