### PR TITLE
Update CI workflow to use Windows 2022

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.10', '1.11']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2022]
         arch: [x64, arm64]
         pocl: [jll, local]
         exclude:
           - os: ubuntu-24.04
             arch: arm64
-          - os: windows-2025
+          - os: windows-2022
             arch: arm64
           - os: ubuntu-24.04-arm
             arch: x64
@@ -41,7 +41,7 @@ jobs:
             pocl: local
           - os: macOS-15
             pocl: local
-          - os: windows-2025
+          - os: windows-2022
             pocl: local
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
See https://github.com/JuliaGPU/OpenCL.jl/issues/393 and https://github.com/JuliaGPU/OpenCL.jl/pull/405