### PR TITLE
support emitting a generated function

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -50,7 +50,7 @@ synchronize(backend)
 ```
 """
 macro kernel(expr)
-    return __kernel(expr, #=generate_cpu=# true, #=force_inbounds=# false, #=unsafe_indices=# false, #=generated=# false)
+    return __kernel(__module__, expr, #=generate_cpu=# true, #=force_inbounds=# false, #=unsafe_indices=# false, #=generated=# false)
 end
 
 """
@@ -69,7 +69,7 @@ This allows for two different configurations:
 """
 macro kernel(ex...)
     if length(ex) == 1
-        return __kernel(ex[1], true, false, false, false)
+        return __kernel(__module__, ex[1], true, false, false, false)
     else
         generate_cpu = true
         unsafe_indices = false
@@ -99,7 +99,7 @@ macro kernel(ex...)
                 )
             end
         end
-        return __kernel(ex[end], generate_cpu, force_inbounds, unsafe_indices, generated)
+        return __kernel(__module__, ex[end], generate_cpu, force_inbounds, unsafe_indices, generated)
     end
 end
 

--- a/test/reflection.jl
+++ b/test/reflection.jl
@@ -15,6 +15,11 @@ end
     A[I] = i + C[I]
 end
 
+@kernel generated = true function f(::Val{N}) where {N}
+    KernelAbstractions.Extras.@unroll $N for i in 1:10
+    end
+end
+
 function test_typed_kernel_dynamic(backend, backend_str, ArrayT)
     A = ArrayT(ones(Float32, 1024, 1024))
     kernel = mul2(backend())
@@ -102,5 +107,6 @@ function reflection_testsuite(backend, backend_str, ArrayT)
     test_typed_kernel_static(backend, backend_str, ArrayT)
     test_typed_kernel_no_optimize(backend, backend_str, ArrayT)
     test_expr_kernel(backend, backend_str, ArrayT)
+    test_generated_kernel(backend, backend_str, ArrayT)
     return
 end


### PR DESCRIPTION
Motivated by #665

Proposed syntax

```
@kernel generated=true function f(::Val{N}) where N
           KernelAbstractions.Extras.@unroll $N for i in 1:10
           end
       end
```

Sadly this doesn't quite work yet, since I need to handle the `$N` correctly

Currently:

```
    function cpu_f(__ctx__, ::Val{N}; ) where N
        if $(Expr(:generated))
            $(Expr(:copyast, :($(QuoteNode(:(let
      begin
          var"##N#249" = length((KernelAbstractions.__workitems_iterspace)(__ctx__))
          begin
              #= /home/vchuravy/src/KernelAbstractions/src/macros.jl:317 =#
              for var"##I#248" = (KernelAbstractions.__workitems_iterspace)(__ctx__)
                  #= /home/vchuravy/src/KernelAbstractions/src/macros.jl:318 =#
                  (KernelAbstractions.__validindex)(__ctx__, var"##I#248") || continue
                  #= /home/vchuravy/src/KernelAbstractions/src/macros.jl:319 =#
                  #= /home/vchuravy/src/KernelAbstractions/src/macros.jl:320 =#
                  #= REPL[19]:2 =# KernelAbstractions.Extra.@unroll $(Expr(:$, :N)) for i = 1:10
                          #= REPL[19]:2 =#
                          #= REPL[19]:3 =#
                      end
                  #= /home/vchuravy/src/KernelAbstractions/src/macros.jl:321 =#
              end
          end
      end
      return nothing
  end))))))
        else
            $(Expr(:meta, :generated_only))
        end
    end
```

Whereas

```
julia> @macroexpand @generated function(::Val{N}) where N
           quote
               KernelAbstractions.Extras.@unroll $N for i in 1:10
               end
           end
       end
:(function (::Val{N},) where N
      #= REPL[18]:1 =#
      if $(Expr(:generated))
          #= REPL[18]:1 =#
          #= REPL[18]:2 =#
          Core._expr(:block, $(QuoteNode(:(#= REPL[18]:3 =#))), Core._expr(:macrocall, $(Expr(:copyast, :($(QuoteNode(:(KernelAbstractions.Extras.var"@unroll")))))), $(QuoteNode(:(#= REPL[18]:3 =#))), N, $(Expr(:copyast, :($(QuoteNode(:(for i = 1:10
      #= REPL[18]:3 =#
      #= REPL[18]:4 =#
  end))))))))
      else
          $(Expr(:meta, :generated_only))
          return
      end
  end)
```

Note that the QuoteNode got broken into smaller pieces with the interpolated variable being left alone and the rest being passed to `_expr` and `QuoteNode`
