### PR TITLE
CI: test on Apple ARM64 (macOS-15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.10', '1.11', '1.12', '1.13-nightly']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15-intel, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15-intel, macOS-15, windows-2022]
         arch: [x64, arm64]
         pocl: [jll, local]
         exclude:
@@ -35,6 +35,10 @@ jobs:
           - os: macOS-15-intel
             arch: arm64
           - os: macOS-15-intel
+            pocl: local
+          - os: macOS-15
+            arch: x64
+          - os: macOS-15
             pocl: local
           - os: windows-2022
             pocl: local


### PR DESCRIPTION
## Summary
- Add `macOS-15` (Apple ARM64) to the CI OS matrix alongside the existing `macOS-15-intel` runner.
- Exclude x64 and local-PoCL builds for `macOS-15` (mirrors the intel exclusions; local PoCL build uses apt-get).

## Test plan
- [ ] CI matrix expands to include `macOS-15` / arm64 / pocl=jll jobs across all Julia versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)