### PR TITLE
Actually use the llvm backend and not the khronos backend

### DIFF
--- a/src/pocl/pocl.jl
+++ b/src/pocl/pocl.jl
@@ -42,6 +42,7 @@ end
 
 using GPUCompiler
 import LLVM
+using SPIRV_LLVM_Backend_jll, SPIRV_Tools_jll
 using Adapt
 
 ## device overrides


### PR DESCRIPTION
As noticed by Simeon in https://github.com/JuliaGPU/KernelAbstractions.jl/pull/626#issuecomment-4660666876
