### PR TITLE
[CI] Don't precompile needlessly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,6 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@cuda"
-      JULIA_PKG_PRECOMPILE_AUTO: false
 
   # - label: "CUDA Enzyme Julia {{matrix.version}}"
   #   matrix:
@@ -97,8 +96,6 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@metal"
-      JULIA_PKG_PRECOMPILE_AUTO: false
-
 
   - label: "oneAPI Julia {{matrix.version}}"
     matrix:
@@ -132,7 +129,6 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@oneAPI"
-      JULIA_PKG_PRECOMPILE_AUTO: false
 
   - label: "AMDGPU Julia {{matrix.version}}"
     matrix:
@@ -168,7 +164,6 @@ steps:
     env:
       JULIA_PROJECT: "@amdgpu"
       JULIA_NUM_THREADS: 4
-      JULIA_PKG_PRECOMPILE_AUTO: false
 
   - label: "OpenCL Julia {{matrix.version}}"
     matrix:
@@ -203,8 +198,8 @@ steps:
     env:
       OCL_ICD_FILENAMES: "libnvidia-opencl.so.1"
       JULIA_PROJECT: "@OpenCL"
-      JULIA_PKG_PRECOMPILE_AUTO: false
 
 env:
+  JULIA_PKG_PRECOMPILE_AUTO: false
   JULIA_PKG_SERVER: "" # it often struggles with our large artifacts
   SECRET_CODECOV_TOKEN: "c5pjPUwULD2L8ss0gRtjCPiagRlTQ11TdbZP6gIhTPeA/gN5w5/7JvDCg36UpKER6FXnQDeBGGkQafHiLdBaH/FWQ2B2VKErtBarIBJa2zWvKu8mYs9PJzw/qLGT2sMXI9kcao63H6/HAwbslJcY0a5Mg+SwM3M05XqSHgnrHMnbBXysKP6VzFEIX7uoyEKOnoWDj8rGJKFYLW2DBRtd6Yc23ESfFXPAqbS7sgXxwQHKzz20FMQBJUmbiDIzPlk3k2n2TvgAWQ0VNK0e4/UooMbULL3UjY4oaMOF0XpJAnWlmvGgy8gEnZKSVp3ieXy/Ubu7BWwH/BT59wDy6LuDxA==;U2FsdGVkX18Wil69f7qJYu6yU5iNx+Zq8akUcOp+McU1CR4Jw4QBsrUKIF4W4uK+/752FQo40BwFsfnIC8CJ/Q=="

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,7 +33,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@cuda"
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
+      JULIA_PKG_PRECOMPILE_AUTO: false
 
   # - label: "CUDA Enzyme Julia {{matrix.version}}"
   #   matrix:
@@ -97,7 +97,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@metal"
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
+      JULIA_PKG_PRECOMPILE_AUTO: false
 
 
   - label: "oneAPI Julia {{matrix.version}}"
@@ -132,7 +132,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@oneAPI"
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
+      JULIA_PKG_PRECOMPILE_AUTO: false
 
   - label: "AMDGPU Julia {{matrix.version}}"
     matrix:
@@ -168,7 +168,7 @@ steps:
     env:
       JULIA_PROJECT: "@amdgpu"
       JULIA_NUM_THREADS: 4
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
+      JULIA_PKG_PRECOMPILE_AUTO: false
 
   - label: "OpenCL Julia {{matrix.version}}"
     matrix:
@@ -203,7 +203,7 @@ steps:
     env:
       OCL_ICD_FILENAMES: "libnvidia-opencl.so.1"
       JULIA_PROJECT: "@OpenCL"
-      JULIA_PKG_PRECOMPILE_AUTO: "0"
+      JULIA_PKG_PRECOMPILE_AUTO: false
 
 env:
   JULIA_PKG_SERVER: "" # it often struggles with our large artifacts

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -79,10 +79,10 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |
-      julia -e 'println("--- :julia: Developing Metal")
+      JULIA_PKG_PRECOMPILE_AUTO=0 julia -e 'println("--- :julia: Developing Metal")
                 using Pkg
                 Pkg.add(url="https://github.com/JuliaGPU/Metal.jl", rev="kaintr")'
-      julia -e 'println("--- :julia: Instantiating project")
+      JULIA_PKG_PRECOMPILE_AUTO=0 julia -e 'println("--- :julia: Instantiating project")
                 using Pkg
                 Pkg.develop(; path=pwd())' || exit 3
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -33,6 +33,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@cuda"
+      JULIA_PKG_PRECOMPILE_AUTO: "0"
 
   # - label: "CUDA Enzyme Julia {{matrix.version}}"
   #   matrix:
@@ -79,10 +80,10 @@ steps:
       - JuliaCI/julia-coverage#v1:
           codecov: true
     command: |
-      JULIA_PKG_PRECOMPILE_AUTO=0 julia -e 'println("--- :julia: Developing Metal")
+      julia -e 'println("--- :julia: Developing Metal")
                 using Pkg
                 Pkg.add(url="https://github.com/JuliaGPU/Metal.jl", rev="kaintr")'
-      JULIA_PKG_PRECOMPILE_AUTO=0 julia -e 'println("--- :julia: Instantiating project")
+      julia -e 'println("--- :julia: Instantiating project")
                 using Pkg
                 Pkg.develop(; path=pwd())' || exit 3
 
@@ -96,6 +97,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@metal"
+      JULIA_PKG_PRECOMPILE_AUTO: "0"
 
 
   - label: "oneAPI Julia {{matrix.version}}"
@@ -130,6 +132,7 @@ steps:
       - exit_status: 3
     env:
       JULIA_PROJECT: "@oneAPI"
+      JULIA_PKG_PRECOMPILE_AUTO: "0"
 
   - label: "AMDGPU Julia {{matrix.version}}"
     matrix:
@@ -165,6 +168,7 @@ steps:
     env:
       JULIA_PROJECT: "@amdgpu"
       JULIA_NUM_THREADS: 4
+      JULIA_PKG_PRECOMPILE_AUTO: "0"
 
   - label: "OpenCL Julia {{matrix.version}}"
     matrix:
@@ -199,6 +203,7 @@ steps:
     env:
       OCL_ICD_FILENAMES: "libnvidia-opencl.so.1"
       JULIA_PROJECT: "@OpenCL"
+      JULIA_PKG_PRECOMPILE_AUTO: "0"
 
 env:
   JULIA_PKG_SERVER: "" # it often struggles with our large artifacts


### PR DESCRIPTION
Currently wastes a lot of time precompiling for invalid intermediate env configurations. Disables precompilation at every step of environment preparation to only precompile the actual test environment 

Testing with Metal but if it pans out I'll implement it for all pipelines if it pans out