### PR TITLE
Remove per-launch heap allocation in CPU `__run`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KernelAbstractions"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
-version = "0.9.41"
+version = "0.9.42"
 
 [deps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -97,16 +97,12 @@ end
 # Inference barriers
 function __run(obj, ndrange, iterspace, args, dynamic, static_threads)
     N = length(iterspace)
-    Nthreads = Threads.nthreads()
-    if Nthreads == 1
-        len, rem = N, 0
+    nthreads = Threads.nthreads()
+    Nthreads, len, rem = if nthreads == 1
+        1, N, 0
     else
-        len, rem = divrem(N, Nthreads)
-    end
-    # not enough iterations for all the threads?
-    if len == 0
-        Nthreads = N
-        len, rem = 1, 0
+        l, r = divrem(N, nthreads)
+        l == 0 ? (N, 1, 0) : (nthreads, l, r)
     end
     if Nthreads == 1
         __thread_run(1, len, rem, obj, ndrange, iterspace, args, dynamic)

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -97,23 +97,28 @@ end
 # Inference barriers
 function __run(obj, ndrange, iterspace, args, dynamic, static_threads)
     N = length(iterspace)
-    nthreads = Threads.nthreads()
-    Nthreads, len, rem = if nthreads == 1
-        1, N, 0
+    Nthreads = Threads.nthreads()
+    if Nthreads == 1
+        len, rem = N, 0
     else
-        l, r = divrem(N, nthreads)
-        l == 0 ? (N, 1, 0) : (nthreads, l, r)
+        len, rem = divrem(N, Nthreads)
+    end
+    if len == 0
+        Nthreads = N
+        len, rem = 1, 0
     end
     if Nthreads == 1
         __thread_run(1, len, rem, obj, ndrange, iterspace, args, dynamic)
     else
-        if static_threads
-            Threads.@threads :static for tid in 1:Nthreads
-                __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
-            end
-        else
-            @sync for tid in 1:Nthreads
-                Threads.@spawn __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
+        let len = len, rem = rem, Nthreads = Nthreads
+            if static_threads
+                Threads.@threads :static for tid in 1:Nthreads
+                    __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
+                end
+            else
+                @sync for tid in 1:Nthreads
+                    Threads.@spawn __thread_run(tid, len, rem, obj, ndrange, iterspace, args, dynamic)
+                end
             end
         end
     end

--- a/src/cpu.jl
+++ b/src/cpu.jl
@@ -103,6 +103,7 @@ function __run(obj, ndrange, iterspace, args, dynamic, static_threads)
     else
         len, rem = divrem(N, Nthreads)
     end
+    # not enough iterations for all the threads?
     if len == 0
         Nthreads = N
         len, rem = 1, 0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,11 @@ A = zeros(Int, Threads.nthreads())
 kern_static(CPU(static = true), (1,))(A, ndrange = length(A))
 @test A == 1:Threads.nthreads()
 
+@testset "__run does not box (no per-launch Core.Box)" begin
+    ci = only(code_lowered(KernelAbstractions.__run, NTuple{6, Any}))
+    @test !any(e -> occursin("Box", string(e)), ci.code)
+end
+
 @kernel cpu = false function my_no_cpu_kernel(a)
 end
 @test_throws ErrorException("This kernel is unavailable for backend CPU") my_no_cpu_kernel(CPU())


### PR DESCRIPTION
the current `__run` function leads to heap allocation because it boxes the args.
Apparently the problem is with `len` and `rem` that are boxed because of being defined inside an if condition which leads to boxing of the whole args. In Oceananigans, these args are typically very large (we can get easily to MB) which in turn leads to a lot of GC getting called.

MWE:
```julia
julia> ci = only(code_lowered(KernelAbstractions.__run, NTuple{6, Any}));

julia> !any(e -> occursin("Box", string(e)), ci.code)
false
```

This is a backport given that KA main switched to POCL,

cc @giordano 