### PR TITLE
Bump pocl_standalone_jll compat to 7.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -52,7 +52,7 @@ SparseArrays = "<0.0.1, 1.6"
 StaticArrays = "0.12, 1.0"
 UUIDs = "<0.0.1, 1.6"
 julia = "1.10"
-pocl_standalone_jll = "7.1.2"
+pocl_standalone_jll = "7.2"
 
 [extras]
 EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"


### PR DESCRIPTION
Updates the `pocl_standalone_jll` compat entry in `Project.toml` from `7.1.2` to `7.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)