### PR TITLE
Fix KA global linear index

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -189,7 +189,7 @@ steps:
 
       julia -e 'println("+++ :julia: Running tests")
                 using Pkg
-                Pkg.test("OpenCL"; coverage=true, test_args=`--platform=cuda kernelabstractions`)'
+                Pkg.test("OpenCL"; coverage=true, test_args=`--platform=nvidia nvidia/kernelabstractions`)'
     agents:
       queue: "cuda"
     timeout_in_minutes: 120

--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -497,7 +497,9 @@ end
 end
 
 @inline function __index_Global_Linear(ctx)
-    return KI.get_global_id().x
+    I = @inbounds expand(__iterspace(ctx), KI.get_group_id().x, KI.get_local_id().x)
+    # TODO: This is unfortunate, can we get the linear index cheaper
+    return @inbounds LinearIndices(__ndrange(ctx))[I]
 end
 
 @inline function __index_Local_Cartesian(ctx)

--- a/test/test.jl
+++ b/test/test.jl
@@ -120,6 +120,12 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         synchronize(backend)
         @test all(Array(A) .== LinearIndices(A))
 
+        # linear index for n > 1 dims
+        A = allocate(backend, Int, 40, 40, 40)
+        index_linear_global(backend)(A, ndrange = size(A))
+        synchronize(backend)
+        @test all(Array(A) .== LinearIndices(A))
+
         A = allocate(backend, Int, 8)
         index_linear_local(backend, 8)(A, ndrange = length(A))
         synchronize(backend)


### PR DESCRIPTION
(do not squash)
It's like this in CUDA, I [fixed it](https://github.com/JuliaGPU/Metal.jl/pull/496) in Metal, I don't know why I got it wrong with the KI PR