### PR TITLE
Add regression test for #613

### DIFF
--- a/test/test.jl
+++ b/test/test.jl
@@ -165,6 +165,22 @@ function unittest_testsuite(Backend, backend_str, backend_mod, BackendArrayT; sk
         @test all(Array(A) .== 1:5)
     end
 
+    @conditional_testset "2D ndrange with scalar workgroupsize" skip_tests begin
+        # A scalar workgroupsize combined with a 2D ndrange pads the first
+        # dimension of the iteration space to a multiple of the workgroupsize.
+        # The padded work items must be masked, otherwise their linear index
+        # reaches past `prod(dims)` (issue #613).
+        backend = Backend()
+        dims = (33, 32)
+        wgsize = 16
+        padding = cld(dims[1], wgsize) * wgsize - dims[1]
+        A = KernelAbstractions.zeros(backend, Int, prod(dims) + padding)
+        index_linear_global(backend, wgsize)(A, ndrange = dims)
+        synchronize(backend)
+        @test all(Array(A)[1:prod(dims)] .== 1:prod(dims))
+        @test all(Array(A)[(prod(dims) + 1):end] .== 0)
+    end
+
     @kernel function constarg(A, @Const(B))
         I = @index(Global)
         @inbounds A[I] = B[I]


### PR DESCRIPTION
Adds a regression test for #613: launching a kernel with a scalar workgroupsize over a 2D ndrange pads the first dimension of the iteration space to a multiple of the workgroupsize. On the POCL backend the padded work items were not masked, so a linear `@index(Global)` reached past `prod(ndrange)` and `@inbounds` writes stochastically segfaulted.

The original MWE only fails intermittently, so the test detects the failure mode deterministically instead: it writes linear indices into a flat array with room for the overshoot and checks that the tail stays untouched. Running the same kernel with `unsafe_indices=true` (masking skipped) trips the check, confirming it catches unmasked padded work items.

The reproducer no longer fails on current `main` with the vendored POCL (both at the test shape and the original 300×5000 / workgroupsize 256 shape from the issue), so this guards against regressions; #613 can likely be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)