### PR TITLE
[pocl] Drop dead deferred-codegen bodies before SPIR-V translation

### DIFF
--- a/src/pocl/compiler/compilation.jl
+++ b/src/pocl/compiler/compilation.jl
@@ -136,7 +136,44 @@ function GPUCompiler.finish_linked_module!(@nospecialize(job::OpenCLCompilerJob)
         )
         GPUCompiler.add_input_arguments!(job, mod, f, kernel_intrinsics)
     end
+
     return
+end
+
+function GPUCompiler.finish_ir!(
+        @nospecialize(job::OpenCLCompilerJob),
+        mod::LLVM.Module, entry::LLVM.Function
+    )
+    entry = invoke(
+        GPUCompiler.finish_ir!,
+        Tuple{CompilerJob{SPIRVCompilerTarget}, LLVM.Module, LLVM.Function},
+        job, mod, entry
+    )
+
+    # Deferred-codegen entrypoints -- notably the wrappers Enzyme generates -- are
+    # held externally live across `InternalizePass` so that linking can resolve
+    # them. Once linked and `alwaysinline`d they are dead, but external linkage
+    # keeps `GlobalDCEPass` from dropping them, so the SPIR-V backend still has to
+    # translate a function it cannot express: they take first-class aggregates
+    # containing `addrspace(1)` pointers, and extracting one back out miscompiles
+    # (the backend types the struct member as a pointer-to-uchar but the extract
+    # result as pointer-to-double, which fails `spirv-val`).
+    #
+    # Drop the bodies of unreferenced non-kernel definitions so only declarations
+    # remain. We empty rather than erase so the `finish_ir!` loop over the
+    # remaining deferred jobs can still look them up by name.
+    if job.config.kernel
+        for f in functions(mod)
+            f == entry && continue
+            isdeclaration(f) && continue
+            LLVM.isintrinsic(f) && continue
+            LLVM.callconv(f) == LLVM.API.LLVMSPIRKERNELCallConv && continue
+            isempty(uses(f)) || continue
+            empty!(f)
+        end
+    end
+
+    return entry
 end
 
 


### PR DESCRIPTION
Companion to EnzymeAD/Enzyme.jl#3405. Needed to make Enzyme work over the POCL backend (x-ref #583, EnzymeAD/Enzyme.jl#3309). Standalone — does not depend on #583.

### Problem

Deferred-codegen entrypoints — notably the wrappers Enzyme generates — are held externally live across GPUCompiler's `InternalizePass` so linking can resolve them. Once linked and `alwaysinline`d they are dead, but external linkage keeps `GlobalDCEPass` from dropping them, so the SPIR-V backend still has to translate a function it cannot express.

These wrappers take first-class aggregates containing `addrspace(1)` pointers. Extracting one back out miscompiles — the backend types the struct member as pointer-to-uchar but the extract result as pointer-to-double:

```
error: Result type (OpTypePointer) does not match the type that results from indexing into the composite (OpTypePointer).
  %105 = OpCompositeExtract %_ptr_CrossWorkgroup_double %91 0
```

This reproduces with no Enzyme involved:

```llvm
target datalayout = "e-i64:64-...-G1"
target triple = "spirv64-unknown-unknown"

define spir_func void @extract_from_byval_struct({ ptr addrspace(1), i64 } %arg) {
  %p = extractvalue { ptr addrspace(1), i64 } %arg, 0
  store double 1.0, ptr addrspace(1) %p, align 8
  ret void
}
```

so the real fix belongs upstream in the LLVM SPIR-V backend. Setting `spir_func` on the wrapper is not sufficient — I checked.

### This change

Empty the bodies of unreferenced non-kernel definitions in `finish_ir!`, so only declarations reach the backend. `finish_ir!` is the right hook because it runs after `AlwaysInlinerPass` (which is what makes these functions dead) and after the `cleanup` `GlobalDCEPass` that would otherwise have handled them. We empty rather than erase so the `finish_ir!` loop over the remaining deferred jobs can still look them up by name.

Guarded on `job.config.kernel` so it runs once for the entry job, not again for each deferred job.

### Result

With this plus EnzymeAD/Enzyme.jl#3405, forward-mode Enzyme over a POCL kernel compiles, runs on device and produces correct derivatives:

```
KA POCL FORWARD-MODE ENZYME: PASS  (dA[1:4] = [2.0, 4.0, 6.0, 8.0])
```

Reverse mode remains blocked on a separate LLVM SPIR-V backend segfault in `SPIRVInstructionSelector::selectExtractVal`; see the Enzyme PR for the minimal reproducer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)