### PR TITLE
Tests for host interface functions

### DIFF
--- a/src/KernelAbstractions.jl
+++ b/src/KernelAbstractions.jl
@@ -168,7 +168,7 @@ this asynchronous version, which requires additional lifetime guarantees as docu
 function copyto! end
 
 """
-    pagelock!(::Backend, dest::AbstractArray)
+    pagelock!(::Backend, dest::AbstractArray)::Union{Nothing, Missing}
 
 Pagelock (pin) a host memory buffer for a backend device. This may be necessary for [`copyto!`](@ref)
 to perform asynchronously w.r.t to the host/
@@ -680,7 +680,7 @@ Returns whether `Float64` values are supported by the backend.
 supports_float64(::Backend) = true
 
 """
-    priority!(::Backend, prio::Symbol)
+    priority!(::Backend, prio::Symbol)::Nothing
 
 Set the priority for the backend stream/queue. This is an optional
 feature that backends may or may not implement. If a backend shall
@@ -739,7 +739,7 @@ function ndevices(::Backend)
 end
 
 """
-    device!(backend::Backend, id::Int)
+    device!(backend::Backend, id::Int)::Nothing
 
 Select the active device for `backend`. `id` is a 1-based device index and must satisfy
 `1 <= id <= ndevices(backend)`.
@@ -763,7 +763,7 @@ function device!(backend::Backend, id::Int)
 end
 
 """
-    functional(::Backend)
+    functional(::Backend)::Union{Bool, Missing}
 
 Queries if the provided backend is functional. This may mean different
 things for different backends, but generally should mean that the

--- a/test/hostinterface.jl
+++ b/test/hostinterface.jl
@@ -11,15 +11,15 @@ function hostinterface_testsuite(_backend, AT)
     @testset "device management" begin
         @test KernelAbstractions.device(backend) isa Int
         @test KernelAbstractions.ndevices(backend) isa Int
-        @test KernelAbstractions.device!(backend, KernelAbstractions.device(backend)) === nothing
+        KernelAbstractions.device!(backend, KernelAbstractions.device(backend))
         @test_throws ArgumentError KernelAbstractions.device!(backend, 0)
         @test_throws ArgumentError KernelAbstractions.device!(backend, KernelAbstractions.ndevices(backend) + 1)
     end
 
     @testset "priority!" begin
-        @test KernelAbstractions.priority!(backend, :normal) === nothing
-        @test KernelAbstractions.priority!(backend, :high) === nothing
-        @test KernelAbstractions.priority!(backend, :low) === nothing
+        KernelAbstractions.priority!(backend, :normal)
+        KernelAbstractions.priority!(backend, :high)
+        KernelAbstractions.priority!(backend, :low)
         @test_throws ErrorException KernelAbstractions.priority!(backend, :bogus)
     end
 

--- a/test/hostinterface.jl
+++ b/test/hostinterface.jl
@@ -1,0 +1,78 @@
+function hostinterface_testsuite(_backend, AT)
+    backend = _backend()
+
+    @testset "capability queries" begin
+        @test KernelAbstractions.supports_unified(backend) isa Bool
+        @test KernelAbstractions.supports_atomics(backend) isa Bool
+        @test KernelAbstractions.supports_float64(backend) isa Bool
+        @test KernelAbstractions.functional(backend) isa Union{Missing, Bool}
+    end
+
+    @testset "device management" begin
+        @test KernelAbstractions.device(backend) isa Int
+        @test KernelAbstractions.ndevices(backend) isa Int
+        @test KernelAbstractions.device!(backend, KernelAbstractions.device(backend)) === nothing
+        @test_throws ArgumentError KernelAbstractions.device!(backend, 0)
+        @test_throws ArgumentError KernelAbstractions.device!(backend, KernelAbstractions.ndevices(backend) + 1)
+    end
+
+    @testset "priority!" begin
+        @test KernelAbstractions.priority!(backend, :normal) === nothing
+        @test KernelAbstractions.priority!(backend, :high) === nothing
+        @test KernelAbstractions.priority!(backend, :low) === nothing
+        @test_throws ErrorException KernelAbstractions.priority!(backend, :bogus)
+    end
+
+    @testset "allocation" begin
+        A = KernelAbstractions.allocate(backend, Float32, 8)
+        @test A isa AT{Float32, 1}
+        @test size(A) == (8,)
+
+        Z = KernelAbstractions.zeros(backend, Float32, 4, 4)
+        @test all(iszero, Array(Z))
+
+        O = KernelAbstractions.ones(backend, Float32, 4, 4)
+        @test all(isone, Array(O))
+
+        if KernelAbstractions.supports_unified(backend)
+            U = KernelAbstractions.allocate(backend, Float32, 4; unified = true)
+            @test U isa AbstractArray{Float32}
+        else
+            @test_throws ArgumentError KernelAbstractions.allocate(backend, Float32, 4; unified = true)
+        end
+    end
+
+    @testset "get_backend" begin
+        A = KernelAbstractions.allocate(backend, Float32, 4)
+        @test KernelAbstractions.get_backend(A) isa Backend
+    end
+
+    @testset "pagelock!" begin
+        A = Vector{Float32}(undef, 4)
+        @test KernelAbstractions.pagelock!(backend, A) isa Union{Missing, Nothing}
+    end
+
+
+    @testset "KernelInterface host functions" begin
+        @test KI.max_work_group_size(backend) isa Int
+        @test KI.multiprocessor_count(backend) isa Int
+        @test KI.sub_group_size(backend) isa Int
+        @test KI.shfl_down_types(backend) isa Vector{DataType}
+
+        function ki_hostinterface_kernel(x)
+            i = KI.get_global_id().x
+            if i <= length(x)
+                @inbounds x[i] = 1
+            end
+            return
+        end
+
+        x = AT(zeros(Float32, 4))
+        kernel = KI.@kernel _backend() launch = false ki_hostinterface_kernel(x)
+        @test kernel isa KI.Kernel
+        @test KI.kernel_max_work_group_size(kernel) isa Int
+        @test KI.kernel_max_work_group_size(kernel; max_work_items = 1) == 1
+    end
+
+    return nothing
+end

--- a/test/testsuite.jl
+++ b/test/testsuite.jl
@@ -28,6 +28,7 @@ end
 
 include("test.jl")
 include("interface.jl")
+include("hostinterface.jl")
 include("localmem.jl")
 include("private.jl")
 include("unroll.jl")
@@ -52,6 +53,10 @@ function testsuite(backend, backend_str, backend_mod, AT, DAT; skip_tests = Set{
 
     @conditional_testset "Interface" skip_tests begin
         interface_testsuite(backend, AT)
+    end
+
+    @conditional_testset "HostInterface" skip_tests begin
+        hostinterface_testsuite(backend, AT)
     end
 
     @conditional_testset "Localmem" skip_tests begin


### PR DESCRIPTION
`supports_atomics` in Metal.jl is broken and I realized we should probably test the interface definitions

All Claude and I reviewed