### PR TITLE
Re-enable Float16 in the CPU benchmarks

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -9,16 +9,13 @@ using Random
 
 if !haskey(ENV, "KA_BACKEND")
     const BACKEND = CPU()
-    const Ts = (Float32, Float64)
 else
     backend = ENV["KA_BACKEND"]
     if backend == "CPU"
         const BACKEND = CPU()
-        const Ts = (Float32, Float64)
     elseif backend == "CUDA"
         using CUDA
         const BACKEND = CUDABackend()
-        const Ts = (Float16, Float32, Float64)
     else
         error("Backend $backend not recognized")
     end
@@ -34,7 +31,7 @@ end
 SUITE["saxpy"] = BenchmarkGroup()
 
 let static = BenchmarkGroup()
-    for T in Ts
+    for T in (Float16, Float32, Float64)
         dtype = BenchmarkGroup()
         for N in (64, 256, 512, 1024, 2048, 4096, 16384, 32768, 65536, 262144, 1048576)
             dtype[N] = @benchmarkable begin
@@ -52,7 +49,7 @@ let static = BenchmarkGroup()
 end
 
 let default = BenchmarkGroup()
-    for T in Ts
+    for T in (Float16, Float32, Float64)
         dtype = BenchmarkGroup()
         for N in (64, 256, 512, 1024, 2048, 4096, 16384, 32768, 65536, 262144, 1048576)
             dtype[N] = @benchmarkable begin


### PR DESCRIPTION
Reverts #609.

That PR dropped `Float16` from the benchmark suite on the CPU (POCL) backend because kernel compilation failed with

```
InvalidIRError: unsupported use of half value
```

in `gpu_init_kernel` -> `unsafe_store!` on a `CLDeviceVector{Float16}` — see JuliaGPU/OpenCL.jl#312.

That codegen gap is fixed. Verified locally on Julia 1.12.7 with the current stack:

- the device reports `cl_khr_fp16`
- `KernelAbstractions.zeros(CPU(), Float16, N)` plus the saxpy kernel compiles and runs, with `Z ≈ 2 .* X .+ Y`
- timings are in line with the other element types, so the suite runtime is unaffected:

| T | N=2^10 | N=2^16 | N=2^20 |
|---|---|---|---|
| Float16 | 50.5 µs | 85.2 µs | 165.1 µs |
| Float32 | 44.4 µs | 80.2 µs | 137.0 µs |
| Float64 | 44.6 µs | 81.5 µs | 165.5 µs |

Unrelated Float16 exclusions left in place: `KI.shfl_down_types` still gates on `cl_khr_fp16` at runtime (a genuine capability check), and `test/random.jl` still skips `Float16` for `randexp` because POCL lacks `log1p` for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HAdSmaaExgWV7JbhmyjmGK