### PR TITLE
Fix Float16 normal generation and RNG overlay dispatch

### DIFF
--- a/src/pocl/device/random.jl
+++ b/src/pocl/device/random.jl
@@ -232,8 +232,11 @@ end
     end
 end
 
-@device_override @inline function Random.randn(rng::AbstractRNG, ::Type{T}) where {T <: Union{Float16, Float32}}
-    @invoke Random.randn(rng::AbstractRNG, T::Type{<:AbstractFloat})
+# Use the table-free fallback, but compute it in Float32 because its polar transform can
+# overflow in Float16. Keep this scoped to our RNG: overlay methods take precedence over
+# regular dispatch and an AbstractRNG method would shadow methods for other device RNGs.
+@device_override @inline function Random.randn(rng::Philox2x32, ::Type{T}) where {T <: Union{Float16, Float32}}
+    return T(@invoke Random.randn(rng::AbstractRNG, Float32::Type{<:AbstractFloat}))
 end
 
 ## randexp
@@ -257,8 +260,9 @@ end
     end
 end
 
-@device_override @inline function Random.randexp(rng::AbstractRNG, ::Type{T}) where {T <: Union{Float16, Float32}}
-    @invoke Random.randexp(rng::AbstractRNG, T::Type{<:AbstractFloat})
+# Compute through Float32 to avoid requiring Float16 `log1p` support.
+@device_override @inline function Random.randexp(rng::Philox2x32, ::Type{T}) where {T <: Union{Float16, Float32}}
+    return T(@invoke Random.randexp(rng::AbstractRNG, Float32::Type{<:AbstractFloat}))
 end
 
 @device_override Random.Sampler(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using KernelAbstractions
+using Random
 using Test
 
 include("quality_assurance.jl")
@@ -24,6 +25,29 @@ import KernelAbstractions.POCL: POCL, @opencl, @device_code_llvm
     # an explicit list overrides the device-derived default
     config = POCL.compiler_config(dev; extensions = "+SPV_KHR_expect_assume")
     @test config.target.extensions == "+SPV_KHR_expect_assume"
+end
+
+# `randn`/`randexp` for Float16 route through Random's table-free fallback, whose polar
+# transform overflows in Float16 and whose `log1p` isn't available for Float16 on the
+# device. The device overlays compute in Float32 and convert, so results stay finite.
+if "cl_khr_fp16" in POCL.device().extensions
+    @testset "POCL device RNG: Float16" begin
+        @kernel function f16_rng_kernel(A, B)
+            i = @index(Global, Linear)
+            @inbounds A[i] = Random.randn(Float16)
+            @inbounds B[i] = Random.randexp(Float16)
+        end
+
+        # the overflow this guards against hits a few hundred values in 2^20 draws,
+        # so a small sample would not catch a regression
+        len = 2^20
+        a = KernelAbstractions.zeros(POCLBackend(), Float16, len)
+        b = KernelAbstractions.zeros(POCLBackend(), Float16, len)
+        f16_rng_kernel(POCLBackend())(a, b; ndrange = len)
+        KernelAbstractions.synchronize(POCLBackend())
+        @test all(isfinite, a)
+        @test all(isfinite, b)
+    end
 end
 
 @testset "POCL compilation cache" begin


### PR DESCRIPTION
Compute Philox Float16 normals in Float32 before conversion, avoiding overflow in Random's polar fallback. Do the same for `randexp` to avoid requiring Float16 `log1p` support.

Scope the typed `randn` and `randexp` overlays to `Philox2x32`. Overlay methods take precedence over regular dispatch, so an `AbstractRNG` overlay shadows more specific methods defined for other device RNGs (this is what bit GPUArrays' `ElementRNG` path upstream).

Ports [JuliaGPU/OpenCL.jl#479](https://github.com/JuliaGPU/OpenCL.jl/pull/479) to the POCL back-end.

### Reproduction

Before the fix, `randn(Float16)` in a POCL kernel produces non-finite values at a low but steady rate — 249 out of 2^20 draws on `cpu-haswell`:

```
BEFORE FIX randn nonfinite: 249  randexp nonfinite: 0
AFTER FIX  randn nonfinite: 0    randexp nonfinite: 0
```

The added test draws 2^20 samples for exactly that reason; a small sample would not catch a regression. It costs ~0.04 s of kernel time (the rest of its wall clock is first-launch compilation), and is gated on the device reporting `cl_khr_fp16`.

`randexp(Float16)` already worked on this device, so the `log1p` half of the change is precautionary and matches upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019X2CqtAxNnxqTxgXvz19pJ
